### PR TITLE
refactor: replace CDE logo with a new bilingual Logo component

### DIFF
--- a/frontend/src/components/Controls/SelectionDetails/SelectionDetails.jsx
+++ b/frontend/src/components/Controls/SelectionDetails/SelectionDetails.jsx
@@ -10,8 +10,7 @@ import LanguageSelector from '../LanguageSelector/LanguageSelector.jsx'
 import Loading from '../Loading/Loading.jsx'
 import CIOOSLogoEN from '../../Images/CIOOSNationalLogoBlackEnglish.svg'
 import CIOOSLogoFR from '../../Images/CIOOSNationalLogoBlackFrench.svg'
-import CDELogoEN from '../../Images/CDELogoEN.png'
-import CDELogoFR from '../../Images/CDELogoFR.png'
+import Logo from '../../logo.js'
 import { server } from '../../../config'
 import './styles.css'
 import {
@@ -200,15 +199,7 @@ export default function SelectionDetails({
           }
           title={t('PointDetailsCIOOSLogoTitleText')}
         />
-        <img
-          className='pointDetailsHeaderLogo CDE'
-          src={i18n.language === 'en' ? CDELogoEN : CDELogoFR}
-          title={t('PointDetailsCDELogoTitleText')}
-          onClick={() => {
-            resetFilters()
-            setPolygon()
-          }}
-        />
+        <Logo lang={i18n.language} />
         <button
           className='pointDetailsHeaderIntroButton'
           onClick={() => setShowIntroModal(true)}

--- a/frontend/src/components/Controls/SelectionDetails/styles.css
+++ b/frontend/src/components/Controls/SelectionDetails/styles.css
@@ -71,6 +71,7 @@
   height: 66px;
   display: flex;
   border-bottom: 1px solid lightgray;
+  align-items: center;
 }
 
 .pointDetailsHeaderLogo {

--- a/frontend/src/components/logo.js
+++ b/frontend/src/components/logo.js
@@ -1,0 +1,81 @@
+import React from 'react';
+
+// /src/components/logo.js
+
+/**
+ * Logo component showing bilingual product name.
+ * Props:
+ *  - lang: 'en' | 'fr' | 'both' (default: 'both')
+ *  - stacked: boolean -> if true, lines are stacked even when single language
+ *  - className: optional extra class names
+ */
+const Logo = ({
+    lang,
+}) => {
+
+    if (lang === 'en')
+        return <div className="cioos-logo" style={{
+            fontFamily: "Montserrat, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif",
+            display: 'flex',
+            lineHeight: 0.8,
+            flexDirection: 'column',
+            alignItems: 'center',
+            gap: '0.1rem',
+            color: '#484848ff',
+            width: "290px",
+        }}>
+            <span
+                style={{
+                    fontWeight: 200,
+                    fontSize: '18px',
+                }}
+            >
+                DATA
+            </span>
+            <span
+                style={{
+                    fontSize: '25px',
+                    fontWeight: 400,
+                }}
+            >
+                EXPLORER
+            </span>
+        </div>;
+    else if (lang === 'fr')
+        return <div className="cioos-logo" style={{
+            fontFamily: "Montserrat, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif",
+            lineHeight: 0.9,
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            gap: '0.1rem',
+            width: "290px",
+            color: '#484848ff'
+        }}>
+            <span
+                style={{
+                    fontWeight: 400,
+                    fontSize: '25px',
+                }}
+            >
+                EXPLORATEUR
+            </span>
+            <span
+                style={{
+                    fontSize: '18px',
+                    fontWeight: 200,
+                }}
+            >
+                DE DONNÉES
+            </span>
+        </div>;
+    else {
+        // Error case, raise error
+        console.error(`Invalid lang prop for Logo component: ${lang}`);
+        return null;
+    }
+};
+
+
+
+export default Logo;


### PR DESCRIPTION
This is the logo with the following corrections:
- [ ]  English
<img width="569" height="116" alt="image" src="https://github.com/user-attachments/assets/41dd98de-5a08-4b59-8991-f8a54bf33f69" />

- [ ] French
<img width="577" height="100" alt="image" src="https://github.com/user-attachments/assets/7061d58d-cff0-4433-b58e-c25b7609de5f" />

Slightly different than the original but good enough I think.