### PR TITLE
Update logo in main version

### DIFF
--- a/frontend/src/components/Controls/SelectionDetails/SelectionDetails.jsx
+++ b/frontend/src/components/Controls/SelectionDetails/SelectionDetails.jsx
@@ -10,8 +10,7 @@ import LanguageSelector from '../LanguageSelector/LanguageSelector.jsx'
 import Loading from '../Loading/Loading.jsx'
 import CIOOSLogoEN from '../../Images/CIOOSNationalLogoBlackEnglish.svg'
 import CIOOSLogoFR from '../../Images/CIOOSNationalLogoBlackFrench.svg'
-import CDELogoEN from '../../Images/CDELogoEN.png'
-import CDELogoFR from '../../Images/CDELogoFR.png'
+import Logo from '../../logo.js'
 import { server } from '../../../config'
 import './styles.css'
 import {
@@ -200,15 +199,7 @@ export default function SelectionDetails({
           }
           title={t('PointDetailsCIOOSLogoTitleText')}
         />
-        <img
-          className='pointDetailsHeaderLogo CDE'
-          src={i18n.language === 'en' ? CDELogoEN : CDELogoFR}
-          title={t('PointDetailsCDELogoTitleText')}
-          onClick={() => {
-            resetFilters()
-            setPolygon()
-          }}
-        />
+        <Logo lang={i18n.language} />
         <button
           className='pointDetailsHeaderIntroButton'
           onClick={() => setShowIntroModal(true)}

--- a/frontend/src/components/Controls/SelectionDetails/styles.css
+++ b/frontend/src/components/Controls/SelectionDetails/styles.css
@@ -71,6 +71,7 @@
   height: 66px;
   display: flex;
   border-bottom: 1px solid lightgray;
+  align-items: center;
 }
 
 .pointDetailsHeaderLogo {

--- a/frontend/src/components/logo.js
+++ b/frontend/src/components/logo.js
@@ -1,0 +1,81 @@
+import React from 'react';
+
+// /src/components/logo.js
+
+/**
+ * Logo component showing bilingual product name.
+ * Props:
+ *  - lang: 'en' | 'fr' | 'both' (default: 'both')
+ *  - stacked: boolean -> if true, lines are stacked even when single language
+ *  - className: optional extra class names
+ */
+const Logo = ({
+    lang,
+}) => {
+
+    if (lang === 'en')
+        return <div className="cioos-logo" style={{
+            fontFamily: "Montserrat, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif",
+            display: 'flex',
+            lineHeight: 0.8,
+            flexDirection: 'column',
+            alignItems: 'center',
+            gap: '0.1rem',
+            color: '#484848ff',
+            width: "290px",
+        }}>
+            <span
+                style={{
+                    fontWeight: 200,
+                    fontSize: '18px',
+                }}
+            >
+                DATA
+            </span>
+            <span
+                style={{
+                    fontSize: '25px',
+                    fontWeight: 400,
+                }}
+            >
+                EXPLORER
+            </span>
+        </div>;
+    else if (lang === 'fr')
+        return <div className="cioos-logo" style={{
+            fontFamily: "Montserrat, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif",
+            lineHeight: 0.9,
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            gap: '0.1rem',
+            width: "290px",
+            color: '#484848ff'
+        }}>
+            <span
+                style={{
+                    fontWeight: 400,
+                    fontSize: '25px',
+                }}
+            >
+                EXPLORATEUR
+            </span>
+            <span
+                style={{
+                    fontSize: '18px',
+                    fontWeight: 200,
+                }}
+            >
+                DE DONNÉES
+            </span>
+        </div>;
+    else {
+        // Error case, raise error
+        console.error(`Invalid lang prop for Logo component: ${lang}`);
+        return null;
+    }
+};
+
+
+
+export default Logo;


### PR DESCRIPTION
This pull request refactors how the bilingual product logo is rendered in the selection details header, replacing static image assets with a new React component for improved flexibility and maintainability. It also makes a minor style adjustment to better align header elements.

**Logo rendering improvements:**

* Added a new `Logo` React component in `frontend/src/components/logo.js` that displays the bilingual product name based on the current language, replacing the previous static image approach. (`[frontend/src/components/logo.jsR1-R81](diffhunk://#diff-810d9f8fe36f5e66f9aff1e5292170b38637ec82a73f6593a01bdfa12ce57b81R1-R81)`)
* Updated `SelectionDetails.jsx` to use the new `Logo` component instead of separate English and French logo images, simplifying language switching and removing unused image imports. (`[[1]](diffhunk://#diff-0f14f26150d9d31fa5e21b16d802ebfccd168b722b5908fe66381dca382eff52L13-R13)`, `[[2]](diffhunk://#diff-0f14f26150d9d31fa5e21b16d802ebfccd168b722b5908fe66381dca382eff52L203-R202)`)

**UI styling adjustment:**

* Modified the `.pointDetailsHeader` CSS class to vertically center its contents for better visual alignment. (`[frontend/src/components/Controls/SelectionDetails/styles.cssR74](diffhunk://#diff-aa3f99274492b68ebe8e077aa8e25b5e62744f088a6d602f7150054db02b118cR74)`)