### PR TITLE
Update standard names for harvester metrics

### DIFF
--- a/harvester/cde_harvester/__main__.py
+++ b/harvester/cde_harvester/__main__.py
@@ -37,6 +37,8 @@ sentry_sdk.init(
     environment=os.environ.get("ENVIRONMENT", "development"),
 )
 
+# Ignored standard names that are not EOVs, mostly coordinate variables
+IGNORED_STANDARD_NAMES= ["latitude", "longitude", "time", "depth", "","altitude","sea_water_pressure","sea_water_pressure_due_to_sea_water"]
 
 def setup_logging(log_time, log_level):
     # setup logging
@@ -113,14 +115,12 @@ def main(erddap_urls, cache_requests, folder, dataset_ids, max_workers):
         variables.query("not standard_name.isnull()")["standard_name"].unique().tolist()
     )
 
-    llat_variables = ["latitude", "longitude", "time", "depth", ""]
-
     # this gets a list of all the standard names
 
     standard_names_not_harvested = [
         x
         for x in standard_names_harvested
-        if x not in supported_standard_names + llat_variables
+        if (x not in supported_standard_names + IGNORED_STANDARD_NAMES) and (not x.startswith("platform_"))
     ]
 
     standard_names_not_harvested_that_are_real = [

--- a/harvester/cde_harvester/goos_eov_to_standard_name.json
+++ b/harvester/cde_harvester/goos_eov_to_standard_name.json
@@ -40,6 +40,7 @@
     "concentration_of_colored_dissolved_organic_matter_in_sea_water_expressed_as_equivalent_mass_fraction_of_quinine_sulfate_dihydrate",
     "surface_downwelling_photosynthetic_photon_flux_in_air",
     "surface_downwelling_photosynthetic_photon_flux_in_sea_water",
+    "downwelling_photosynthetic_photon_flux_in_sea_water",
     "surface_downwelling_shortwave_flux_in_air",
     "downwelling_photosynthetic_photon_spherical_irradiance_in_sea_water",
     "chlorophyll_concentration_in_sea_water",
@@ -244,7 +245,8 @@
     "northward_sea_water_velocity_at_sea_floor",
     "upward_sea_water_velocity",
     "sea_water_x_velocity",
-    "sea_water_y_velocity"
+    "sea_water_y_velocity",
+    "direction_of_sea_water_velocity"
   ],
   "subSurfaceSalinity": [
     "sea_surface_salinity",
@@ -254,7 +256,8 @@
     "sea_water_electrical_conductivity",
     "sea_water_density",
     "sea_water_sigma_t",
-    "sea_water_absolute_salinity"
+    "sea_water_absolute_salinity",
+    "square_of_brunt_vaisala_frequency_in_sea_water"
   ],
   "subSurfaceTemperature": [
     "sea_surface_temperature",


### PR DESCRIPTION
Enhance the main harvester by including coordinate variables in the ignored standard names and adding missing standard names for downwelling photosynthetic flux and velocity metrics.