### PR TITLE
Hotfix: prevent JS bundle truncation on explore.cioos.ca (nginx gzip / sendfile)

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,31 +1,54 @@
-user  nginx;events {
-    worker_connections   1000;
+user nginx;
+
+events {
+  worker_connections 1000;
 }
+
 http {
-        server {
-              gzip on;
-              gzip_proxied any;
-              gzip_vary on;
-              gzip_types *;
-              large_client_header_buffers 4 20k ;
-              listen 4000;
+  # Hotfix: avoid partial-send / filesystem + sendfile issues
+  sendfile off;
+  tcp_nopush off;
 
-              location /api/ {
-                proxy_pass http://web-api:5000/;
-              }
-              location /harvester_logs/ {
-                alias /usr/share/nginx/html/harvester_logs/;
-                autoindex on;
-                autoindex_exact_size off;
-                autoindex_localtime on;
-              }
-              location /downloads/ {
-                alias /usr/share/nginx/html/downloads/;
-                autoindex off;
-              }
-              location / {
-                proxy_pass http://frontend:80;
+  server {
+    listen 4000;
 
-              }
-        } 
+    large_client_header_buffers 4 20k;
+
+    # Hotfix: gzip config sane (remove gzip_types *)
+    gzip on;
+    gzip_vary on;
+    gzip_proxied any;
+    gzip_types
+      text/plain
+      text/css
+      application/json
+      application/javascript
+      application/xml
+      image/svg+xml;
+
+    location /api/ {
+      proxy_pass http://web-api:5000/;
+    }
+
+    location /harvester_logs/ {
+      alias /usr/share/nginx/html/harvester_logs/;
+      autoindex on;
+      autoindex_exact_size off;
+      autoindex_localtime on;
+    }
+
+    location /downloads/ {
+      alias /usr/share/nginx/html/downloads/;
+      autoindex off;
+    }
+
+    location / {
+      # Hotfix: avoid gzipping proxied SPA assets until verified
+      gzip off;
+
+      proxy_pass http://frontend:80;
+      proxy_http_version 1.1;
+      proxy_set_header Connection "";
+    }
+  }
 }


### PR DESCRIPTION
Users were seeing a white screen on [https://explore.cioos.ca](https://explore.cioos.ca) due to the SPA failing to load its JS bundles.

Investigation showed that large JS assets were being **truncated mid-transfer**: the server advertises the full `Content-Length`, but the connection consistently closes early. This is reproducible with `curl` and happens for all clients. Byte-range requests for the same files succeed, which indicates the assets themselves are intact and the issue is in the serving layer rather than the frontend build.

This PR applies a minimal, reversible nginx hotfix to avoid known truncation failure modes when proxying large static assets:

- Removes `gzip_types *;` and replaces it with a sane, explicit list
- Disables gzip for the proxied frontend (`location /`) to avoid re-encoding upstream JS/HTML
- Disables `sendfile` / `tcp_nopush` to prevent partial-send issues on certain filesystems or proxy paths
- Hardens proxy connection handling for the frontend (`proxy_http_version 1.1`, cleared `Connection` header)

These changes do not affect application logic and can be reverted once upstream hosting details are verified. They are intended as a safe production hotfix to restore client-side rendering.
