### PR TITLE
Feat/harvest-config-env

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ If you just want to see how a dataset is harvested by CDE:
         - Development: `docker compose run --rm -e INCREMENTAL_MODE=true harvester`
         - Production: `docker compose -f docker-compose.production.yaml run --rm -e INCREMENTAL_MODE=true harvester`
         - Or use the convenience script: `./run_harvester.sh --incremental`
+    3. **Custom config file** (use a different harvest configuration):
+        - Set `HARVEST_CONFIG_FILE` environment variable or override at runtime:
+        - Development: `docker compose run --rm -e HARVEST_CONFIG_FILE=/app/harvester/custom_config.yaml harvester`
+        - Production: `docker compose -f docker-compose.production.yaml run --rm -e HARVEST_CONFIG_FILE=/app/harvester/custom_config.yaml harvester`
 
 For more details, see:
 - [Harvester Usage Guide](HARVESTER_USAGE.md)

--- a/docker-compose.production.yaml
+++ b/docker-compose.production.yaml
@@ -87,6 +87,7 @@ services:
     environment:
       - "DB_HOST_EXTERNAL=$DB_HOST_EXTERNAL"
       - "HARVESTER_LOG_DIR=/app/harvester/logs"
+      - "HARVEST_CONFIG_FILE=/app/harvester/harvest_config.yaml"
     env_file:
       - .env
 volumes:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -70,6 +70,7 @@ services:
       - ./harvester_logs:/app/harvester/logs
     environment:
       - "HARVESTER_LOG_DIR=/app/harvester/logs"
+      - "HARVEST_CONFIG_FILE=/app/harvester/harvest_config.yaml"
     env_file:
       - .env
 

--- a/harvester/README.md
+++ b/harvester/README.md
@@ -77,6 +77,8 @@ python -m cde_harvester --urls https://catalogue.hakai.org/erddap --cache
 
 The harvester is typically run via Docker Compose. See the main [README](../README.md) for details.
 
+The `HARVEST_CONFIG_FILE` environment variable is automatically set in the docker-compose files to `/app/harvester/harvest_config.yaml`. This allows the harvester to automatically use the mounted config file without needing the `-f` flag.
+
 ### Full Reload Mode (default)
 Clears all existing data and reloads everything from scratch:
 ```bash
@@ -89,6 +91,12 @@ Updates only changed datasets, preserving existing data (much faster):
 docker compose run --rm -e INCREMENTAL_MODE=true harvester
 # Or use the convenience script:
 ./run_harvester.sh --incremental
+```
+
+### Using a Custom Config File
+To use a different config file, override the environment variable:
+```bash
+docker compose run --rm -e HARVEST_CONFIG_FILE=/app/harvester/custom_config.yaml harvester
 ```
 
 ## Output Files
@@ -138,6 +146,14 @@ DB_NAME=cde
 # Sentry error tracking (optional)
 SENTRY_DSN=your_sentry_dsn_here
 ENVIRONMENT=development  # or production
+
+# Harvest config file path (optional)
+# When set, automatically uses this config file without needing -f flag
+# Defaults to harvest_config.yaml if not provided
+HARVEST_CONFIG_FILE=/app/harvester/harvest_config.yaml
+
+# Harvester log directory (optional)
+HARVESTER_LOG_DIR=/app/harvester/logs
 ```
 
 ### Configuration File

--- a/harvester/cde_harvester/__main__.py
+++ b/harvester/cde_harvester/__main__.py
@@ -266,17 +266,24 @@ if __name__ == "__main__":
     logger.info("Starting CDE Harvester")
     parser = argparse.ArgumentParser()
 
-    if "-f" in sys.argv or "--file" in sys.argv:
-        # Use config file
+    # Determine if config file should be used
+    config_file_env = os.environ.get("HARVEST_CONFIG_FILE")
+    use_config_file = "-f" in sys.argv or "--file" in sys.argv or config_file_env is not None
+
+    if use_config_file:
+        # Use config file (from command line arg, env var, or default)
         parser.add_argument(
             "-f",
             "--file",
             help="get these options from a config file instead",
-            required=True,
+            required=False,
         )
 
         args = parser.parse_args()
-        config_file = args.file
+        config_file = args.file or config_file_env
+
+        if not config_file:
+            parser.error("Config file must be provided via -f/--file flag or HARVEST_CONFIG_FILE environment variable")
 
         config = load_config(config_file)
         logger.info(


### PR DESCRIPTION
Add ability to define harvest config via env variable

This pull request adds support for specifying a custom harvest configuration file via the `HARVEST_CONFIG_FILE` environment variable, making it easier to use different config files without always needing to pass the `-f` flag. The documentation and Docker Compose files have been updated to reflect this new option.

**Config file selection improvements:**
* The harvester can now use a config file specified by the `HARVEST_CONFIG_FILE` environment variable, falling back to the command-line `-f/--file` flag if the environment variable is not set. The config file is now optional if the environment variable is provided. (`harvester/cde_harvester/__main__.py`)

**Docker Compose enhancements:**
* Added the `HARVEST_CONFIG_FILE` environment variable (defaulting to `/app/harvester/harvest_config.yaml`) to both `docker-compose.yaml` and `docker-compose.production.yaml` for the harvester service, so the default config file is automatically used. (`docker-compose.yaml`, `docker-compose.production.yaml`) [[1]](diffhunk://#diff-3fde9d1a396e140fefc7676e1bd237d67b6864552b6f45af1ebcc27bcd0bb6e9R73) [[2]](diffhunk://#diff-0a1c3356cafa536f2da1e810fe8ae075ca001848b63c20d86b004626789cfa88R90)

**Documentation updates:**
* Updated `README.md` and `harvester/README.md` to document the new environment variable, explain how to use a custom config file, and clarify that the config file is now automatically used in Docker Compose setups. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R33-R36) [[2]](diffhunk://#diff-73d10cafe62b1aba565dcffde460f60f4cd81044164146d3aa9b6be55d274921R80-R81) [[3]](diffhunk://#diff-73d10cafe62b1aba565dcffde460f60f4cd81044164146d3aa9b6be55d274921R96-R101) [[4]](diffhunk://#diff-73d10cafe62b1aba565dcffde460f60f4cd81044164146d3aa9b6be55d274921R149-R156)