### PR TITLE
Feat/improve tests

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,201 @@
+# Architecture
+
+## High-Level Architecture Style
+
+**Hybrid: ETL Pipeline + Microservices + Web Application**
+
+The system combines a nightly batch ETL pipeline (harvest → load) with a set of always-on microservices (web API, download scheduler, frontend) backed by a shared PostgreSQL database.
+
+---
+
+## Architecture Diagram
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                        External Systems                             │
+│  ERDDAP Servers (ocean data)        CKAN (org metadata)             │
+└──────────────────┬──────────────────────────┬───────────────────────┘
+                   │                          │
+          ┌────────▼────────┐                 │
+          │   Harvester     │◄────────────────┘
+          │  (Python ETL)   │  fetches org data per dataset
+          └────────┬────────┘
+                   │ CSVs (datasets, profiles,
+                   │       variables, ckan)
+          ┌────────▼────────┐
+          │   DB Loader     │
+          │  (Python ETL)   │
+          └────────┬────────┘
+                   │ SQL COPY + UPSERT
+          ┌────────▼────────────────────────────────┐
+          │         PostgreSQL 13 + PostGIS 3.1      │
+          │  schema: cde                             │
+          │  tables: datasets, profiles, points,     │
+          │          hexes_zoom_0/1, organizations,  │
+          │          download_jobs                   │
+          └────────┬─────────────────┬──────────────┘
+                   │                 │
+          ┌────────▼────────┐  ┌─────▼──────────────┐
+          │   Web API       │  │ Download Scheduler  │
+          │  (Node/Express) │  │  (Python)           │
+          │  + Redis Cache  │  └─────┬───────────────┘
+          └────────┬────────┘        │
+                   │                 │  queries ERDDAP
+                   │        ┌────────▼────────┐
+                   │        │   Downloader    │
+                   │        │  (Python)       │
+                   │        └────────┬────────┘
+                   │                 │ .zip files
+                   │        ┌────────▼────────┐
+                   │        │   Nginx (files) │◄──── user email link
+                   │        └─────────────────┘
+          ┌────────▼────────┐
+          │    Nginx        │
+          │ (reverse proxy) │
+          └────────┬────────┘
+                   │ HTTP
+          ┌────────▼────────┐
+          │   Frontend      │
+          │ (React/Mapbox)  │
+          └─────────────────┘
+```
+
+---
+
+## Architectural Layers
+
+### Presentation Layer
+**Component:** `frontend/`
+- React 18 SPA with Mapbox GL for spatial interaction
+- Webpack bundled, served by Nginx
+- Bilingual (English/French via i18n)
+
+### API Layer
+**Component:** `web-api/`
+- Express.js REST API
+- Redis caching in production (5-minute TTL)
+- Swagger documentation at `/api-docs`
+- Sentry error tracking
+
+### Scheduler / Worker Layer
+**Component:** `download_scheduler/`
+- Python polling loop (configurable interval)
+- Picks up download jobs from PostgreSQL
+- Coordinates downloader execution
+- Sends email on completion via Gmail SMTP
+
+### Business Logic / ETL Layer
+**Components:** `harvester/`, `downloader/`, `db-loader/`
+- Harvester: Dataset discovery, compliance checking, metadata extraction
+- Downloader: ERDDAP query execution, polygon filtering, size enforcement
+- DB Loader: CSV → PostgreSQL with incremental or full-reload strategy
+
+### Data Access Layer
+**Components:** `web-api/` (Knex.js), `db-loader/` (SQLAlchemy + psycopg2), `download_scheduler/` (psycopg2)
+- Knex.js for API queries (connection pool)
+- SQLAlchemy + raw SQL for batch loads
+- psycopg2 for job queue polling (FOR UPDATE SKIP LOCKED)
+
+### Persistence Layer
+**Component:** `database/`
+- PostgreSQL 13 with PostGIS 3.1
+- Schema: `cde`
+- Hexagonal spatial aggregation (H3-inspired but custom SQL)
+
+### Infrastructure Layer
+**Components:** `docker-compose.yaml`, `docker-compose.production.yaml`, `nginx/`
+- Docker Compose orchestration
+- Nginx reverse proxy with load balancing (4 API replicas in production)
+- Named volumes for data persistence
+
+---
+
+## Core Components Catalog
+
+### `cde_harvester` (Python)
+
+| Class / Module | Responsibility |
+|----------------|---------------|
+| `__main__.py` | Entry point; spins up thread pool, queue, progress bar |
+| `harvest_erddap.py` | Per-server orchestration; dataset list → compliant datasets |
+| `ERDDAP.py` | HTTP client for ERDDAP REST API; disk-cache support |
+| `dataset.py` | `Dataset` class: parses globals, variables, profiles from ERDDAP |
+| `profiles.py` | Extracts profile/timeseries IDs and min/max statistics |
+| `CDEComplianceChecker.py` | Validates required cf_roles, EOV support, depth/altitude exclusions |
+| `utils.py` | EOV/CF standard name mappings, CKAN lookups |
+| `platform_ioos_to_l06.py` | IOOS ↔ NERC L06 platform vocabulary translation |
+| `output.py` | Writes `datasets.csv`, `profiles.csv`, `variables.csv`, `ckan.csv` |
+
+### `cde_db_loader` (Python)
+
+| Class / Module | Responsibility |
+|----------------|---------------|
+| `__main__.py` | CLI entry; chooses full-reload vs incremental path |
+| `db_loader.py` | Full-reload: truncate, COPY, run SQL functions |
+| `incremental_db_loader.py` | Incremental: temp tables, UPSERT, delete stale rows |
+
+### `erddap_downloader` (Python)
+
+| Class / Module | Responsibility |
+|----------------|---------------|
+| `download_erddap.py` | Query builder, ERDDAP data fetch, polygon post-filter |
+| `downloader_wrapper.py` | Temp dir creation, zip packaging, cleanup |
+| `download_pdf.py` | Optional PDF metadata download |
+
+### `download_scheduler` (Python)
+
+| Class / Module | Responsibility |
+|----------------|---------------|
+| `__main__.py` | Event loop; polls DB at interval |
+| `download_scheduler.py` | Job lifecycle: fetch → lock → download → update status → email |
+| `download_email.py` | Gmail SMTP email with Jinja2 HTML templates |
+
+### `web-api` (Node.js)
+
+| Module | Responsibility |
+|--------|---------------|
+| `app.js` | Express setup, middleware, route mounting |
+| `routes/datasets.js` | Dataset listing with i18n translations |
+| `routes/download.js` | Download job creation and status |
+| `routes/tiles.js` | Hexagon tile spatial queries |
+| `routes/pointQuery.js` | Point-in-polygon queries |
+| `routes/organizations.js` | Organization metadata |
+| `routes/oceanVariables.js` | EOV definitions |
+| `db.js` | Knex connection pool configuration |
+| `cache.js` | Redis cache wrapper |
+
+### `frontend` (React)
+
+| Component | Responsibility |
+|-----------|---------------|
+| `Map.js` | Mapbox GL map, polygon/rectangle drawing |
+| `Filter.jsx` | Sidebar query builder |
+| `DatasetsTable.jsx` | Results grid |
+| `DownloadDetails.jsx` | Download form + status |
+| `IntroModal.jsx` | Welcome/help overlay |
+
+---
+
+## Deployment Topology
+
+### Development
+```
+docker-compose.yaml
+  db          (postgres:13-postgis-3.1)
+  web-api     (node, 1 replica)
+  nginx       (reverse proxy)
+  scheduler   (python)
+  frontend    (webpack dev server)
+  harvester   (optional, run manually)
+```
+
+### Production
+```
+docker-compose.production.yaml
+  db          (postgres:13-postgis-3.1, persistent volume)
+  web-api     (4 replicas, load balanced by nginx)
+  redis       (cache)
+  nginx       (reverse proxy + static files)
+  scheduler   (2 replicas, FOR UPDATE SKIP LOCKED ensures no duplicate work)
+  harvester   (run via cron/external trigger)
+```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,164 @@
+# Configuration
+
+## Configuration Sources
+
+The system uses three configuration mechanisms:
+
+1. **Environment variables** — runtime secrets and deployment settings (`.env` files loaded by Docker Compose)
+2. **YAML file** — harvester-specific settings (`harvest_config.yaml`)
+3. **CSV files** — static reference data (ERDDAP server list, platform mappings)
+
+---
+
+## Configuration Loading Sequence
+
+```
+Docker Compose startup
+  └── loads .env (or .env.production via op run)
+        → injects env vars into each container
+
+Harvester startup
+  └── reads harvest_config.yaml (path from -f CLI arg)
+        → erddap_urls, dataset_ids, cache, max-workers, folder, log_dir
+
+DB Loader startup
+  └── reads env vars: DB_NAME, DB_USER, DB_PASSWORD, DB_HOST, DB_PORT
+  └── reads CLI args: --folder, --incremental
+
+Web API startup
+  └── reads env vars: DB_*, REDIS_HOST, CORS_ORIGINS, SENTRY_DSN, etc.
+
+Download Scheduler startup
+  └── reads env vars: DB_*, GMAIL_USER, GMAIL_PASSWORD, DOWNLOAD_WAF_URL, etc.
+```
+
+---
+
+## Environment Variable Matrix
+
+### Database
+
+| Variable | Purpose | Required | Default |
+|----------|---------|----------|---------|
+| `DB_NAME` | PostgreSQL database name | Yes | — |
+| `DB_USER` | PostgreSQL username | Yes | — |
+| `DB_PASSWORD` | PostgreSQL password | Yes | — |
+| `DB_HOST` | PostgreSQL host (internal Docker) | Yes | `db` |
+| `DB_PORT` | PostgreSQL port | No | `5432` |
+| `DB_HOST_EXTERNAL` | PostgreSQL host from outside Docker (harvester) | Yes (harvester) | — |
+
+### API
+
+| Variable | Purpose | Required | Default |
+|----------|---------|----------|---------|
+| `API_URL` | Base URL for API (used by frontend) | Yes | — |
+| `BASE_URL` | Base URL for download links in emails | Yes | — |
+| `CORS_ORIGINS` | Comma-separated allowed origins | Yes | — |
+| `ENABLE_API_DOCS` | Enable Swagger UI at `/api-docs` | No | `false` |
+| `PORT` | API server port | No | `3000` |
+
+### Caching
+
+| Variable | Purpose | Required | Default |
+|----------|---------|----------|---------|
+| `REDIS_HOST` | Redis hostname | No (dev can omit) | — |
+| `REDIS_PORT` | Redis port | No | `6379` |
+
+### Downloader / Scheduler
+
+| Variable | Purpose | Required | Default |
+|----------|---------|----------|---------|
+| `DOWNLOAD_WAF_URL` | Base URL served by Nginx for download files | Yes | — |
+| `CREATE_PDF` | Whether to attempt PDF download alongside data | No | `false` |
+| `DOWNLOAD_POLL_INTERVAL` | Seconds between job queue polls | No | `30` |
+| `INCREMENTAL_MODE` | Use incremental DB load (faster, for nightly runs) | No | `false` |
+
+### Email
+
+| Variable | Purpose | Required | Default |
+|----------|---------|----------|---------|
+| `GMAIL_USER` | Gmail sender address | No | — |
+| `GMAIL_PASSWORD` | Gmail app password | No | — |
+
+### Monitoring
+
+| Variable | Purpose | Required | Default |
+|----------|---------|----------|---------|
+| `SENTRY_DSN` | Sentry project DSN for error reporting | No | — |
+| `ENVIRONMENT` | Environment label sent to Sentry (`production`, `staging`) | No | — |
+| `HARVESTER_LOG_DIR` | Directory for harvester log files | No | `/logs` |
+
+---
+
+## Harvester YAML Configuration (`harvest_config.yaml`)
+
+```yaml
+# List of ERDDAP server base URLs to harvest
+erddap_urls:
+  - https://data.cioospacific.ca/erddap
+  - https://catalogue.ogsl.ca/erddap
+  - ...
+
+# Optional: restrict to specific dataset IDs (for testing)
+dataset_ids:
+  - my_dataset_id_1
+
+# Use disk cache to avoid re-fetching unchanged metadata
+cache: true
+
+# Output directory for CSV files
+folder: harvest
+
+# Number of parallel worker threads per server
+max-workers: 4
+
+# Log file directory
+log_dir: /logs
+```
+
+**Location:** Mounted as a Docker volume; default path `/harvest_config.yaml` inside container.
+
+---
+
+## ERDDAP Server List (`harvester/cioos_erddap_servers.csv`)
+
+A CSV listing all ERDDAP servers to harvest. Columns:
+- `url` — base URL of the ERDDAP server
+- `name` — human-readable institution name
+- `active` — whether to include in harvests
+
+This file is tracked in git and updated manually when new servers are added.
+
+---
+
+## EOV Mapping Files
+
+| File | Location | Purpose |
+|------|----------|---------|
+| `cde_to_goos_eov.json` | `harvester/cde_harvester/` | Maps CDE internal EOV names to GOOS standard names |
+| `goos_eov_to_standard_name.json` | `harvester/cde_harvester/` | Maps GOOS EOV names to CF standard variable names |
+
+These are static reference files maintained in version control. They define which ocean variables (EOVs) the platform supports.
+
+---
+
+## Docker Compose Environment Injection
+
+Development (`.env` file):
+```
+DB_NAME=cioos
+DB_USER=cioos
+DB_PASSWORD=cioos
+DB_HOST=db
+...
+```
+
+Production (`.env.production` with 1Password references):
+```
+DB_PASSWORD=op://Production/postgres/password
+GMAIL_PASSWORD=op://Production/gmail/app-password
+SENTRY_DSN=op://Production/sentry/dsn
+...
+```
+
+Resolved at startup via: `op run --env-file .env.production -- docker compose -f docker-compose.production.yaml up`

--- a/docs/data_flow.md
+++ b/docs/data_flow.md
@@ -1,0 +1,199 @@
+# Data Flow
+
+## Overview
+
+Data enters the system from external ERDDAP servers, is transformed and indexed into PostgreSQL, then served to users who can download subsets back to ERDDAP servers on demand.
+
+---
+
+## Data Flow Diagram
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                    INPUTS (External)                                │
+│                                                                     │
+│  ERDDAP Servers                     CKAN                           │
+│  - dataset metadata (globals)       - organization records          │
+│  - variable metadata                  (name, logo, color)           │
+│  - profile IDs + statistics                                         │
+│  - raw data (on download)                                           │
+└──────────┬──────────────────────────────┬───────────────────────────┘
+           │                              │
+           ▼                              ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│                    HARVESTER (Transform)                            │
+│                                                                     │
+│  1. Fetch dataset list per ERDDAP server                            │
+│  2. Fetch metadata (globals + variables) per dataset                │
+│  3. Validate compliance (EOV support, cf_role, depth/alt)           │
+│  4. Extract profile IDs + min/max (time, depth, lat/lon)            │
+│  5. Map EOVs: CDE → GOOS → CF standard names                        │
+│  6. Map platforms: IOOS codes → NERC L06 codes                      │
+│  7. Lookup organization data from CKAN                              │
+└──────────┬──────────────────────────────────────────────────────────┘
+           │
+           ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│                    INTERMEDIATE (CSV Files)                         │
+│                                                                     │
+│  harvest/datasets.csv    - one row per compliant dataset            │
+│  harvest/profiles.csv    - one row per profile/timeseries           │
+│  harvest/variables.csv   - one row per variable per dataset         │
+│  harvest/ckan.csv        - one row per organization                 │
+└──────────┬──────────────────────────────────────────────────────────┘
+           │
+           ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│                    DB LOADER (Load)                                 │
+│                                                                     │
+│  COPY CSVs → staging tables                                         │
+│  Run SQL: profile_process()  → link profiles to datasets            │
+│  Run SQL: ckan_process()     → upsert organizations                 │
+│  Run SQL: create_hexes()     → build spatial aggregations           │
+│  Run SQL: set_constraints()  → re-add foreign keys                  │
+└──────────┬──────────────────────────────────────────────────────────┘
+           │
+           ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│                    POSTGRESQL (Persistence)                         │
+│                                                                     │
+│  cde.datasets        cde.profiles       cde.organizations           │
+│  cde.variables       cde.points         cde.hexes_zoom_0/1          │
+│                      cde.download_jobs                              │
+└──────────┬─────────────────────────────┬───────────────────────────┘
+           │                             │
+           ▼                             ▼
+┌──────────────────┐           ┌──────────────────────────────────────┐
+│   WEB API        │           │   DOWNLOAD SCHEDULER                 │
+│                  │           │                                      │
+│  Knex queries    │           │  Polls download_jobs table           │
+│  PostGIS spatial │           │  Triggers erddap_downloader          │
+│  Redis cache     │           │  Updates job status                  │
+└────────┬─────────┘           └──────────────┬───────────────────────┘
+         │                                    │
+         ▼                                    ▼
+┌──────────────────┐           ┌──────────────────────────────────────┐
+│   FRONTEND       │           │   ERDDAP SERVERS (Data Download)     │
+│                  │           │                                      │
+│  Map tiles       │           │  Actual oceanographic data rows      │
+│  Dataset table   │           │  (CSV/NetCDF streams)                │
+│  Filter UI       │           └──────────────┬───────────────────────┘
+└──────────────────┘                          │
+                                              ▼
+                               ┌──────────────────────────────────────┐
+                               │   OUTPUTS                            │
+                               │                                      │
+                               │  downloads/{job_id}.zip              │
+                               │    (served by Nginx)                 │
+                               │                                      │
+                               │  Email → user with download link     │
+                               └──────────────────────────────────────┘
+```
+
+---
+
+## Data Schemas
+
+### `datasets.csv` (Harvester Output)
+
+| Column | Type | Description |
+|--------|------|-------------|
+| dataset_id | string | ERDDAP dataset identifier |
+| erddap_url | string | Base URL of source ERDDAP server |
+| title | string | Dataset title |
+| title_fr | string | French title (if available) |
+| summary | string | Description |
+| platform | string | Platform type (NERC L06 code) |
+| eovs | JSON array | List of supported EOV names |
+| organizations | JSON array | CKAN organization IDs |
+| time_min / time_max | datetime | Temporal coverage |
+| lat_min / lat_max | float | Bounding box |
+| lon_min / lon_max | float | Bounding box |
+
+### `profiles.csv` (Harvester Output)
+
+| Column | Type | Description |
+|--------|------|-------------|
+| profile_id | string | Unique profile/timeseries identifier |
+| dataset_id | string | FK to datasets |
+| latitude | float | Profile location |
+| longitude | float | Profile location |
+| time_min / time_max | datetime | Profile temporal range |
+| depth_min / depth_max | float | Profile depth range |
+| n_records | int | Number of data rows |
+
+### `variables.csv` (Harvester Output)
+
+| Column | Type | Description |
+|--------|------|-------------|
+| dataset_id | string | FK to datasets |
+| variable_name | string | CF standard name |
+| eov | string | Mapped EOV name |
+
+---
+
+## Validation Rules (CDEComplianceChecker)
+
+A dataset is harvested only if ALL of the following are true:
+
+1. Has at least one `cf_role` in `{timeSeries, profile, trajectory}`
+2. Has at least one variable mapping to a supported CDE EOV
+3. Does NOT have both `depth` and `altitude` variables (ambiguous vertical axis)
+4. Is not in the explicit exclusion list
+
+Datasets failing validation are recorded in `cde.skipped_datasets` with the failure reason.
+
+---
+
+## Download Data Flow Detail
+
+```
+User request: { polygon_wkt, start_date, end_date, dataset_ids[], email }
+  │
+  ▼
+web-api: INSERT INTO cde.download_jobs
+  → job_id returned to frontend
+  │
+  ▼
+download_scheduler picks up job
+  │
+  ├── for each dataset_id:
+  │     Build ERDDAP URL:
+  │       /erddap/tabledap/{id}.csv
+  │         ?time>={start}&time<={end}
+  │         &latitude>={lat_min}&latitude<={lat_max}   ← bounding box
+  │         &longitude>={lon_min}&longitude<={lon_max}
+  │         &{mandatory_vars},{eov_vars}
+  │
+  │     Stream response → parse CSV
+  │
+  │     If polygon (not just bbox):
+  │       filter rows: Shapely point-in-polygon test
+  │
+  │     If crosses 180° meridian:
+  │       duplicate query with adjusted lon bounds
+  │
+  │     Check size: > 1GB/dataset → skip dataset, log warning
+  │                 > 5GB total   → stop, mark job "over-limit"
+  │
+  └── zip all per-dataset CSVs → {job_id}.zip
+
+UPDATE cde.download_jobs SET status='completed', url=...
+send email → user
+```
+
+---
+
+## EOV Vocabulary Mapping
+
+Data enters ERDDAP with CF standard variable names. The platform maps these to user-facing EOV labels:
+
+```
+CF standard name (e.g. "sea_water_temperature")
+  ↓  [goos_eov_to_standard_name.json inverse lookup]
+GOOS EOV (e.g. "Temperature")
+  ↓  [cde_to_goos_eov.json inverse lookup]
+CDE EOV display name (e.g. "Sea Water Temperature")
+  ↓  [stored in cde.variables, cde.datasets.eovs]
+Frontend filter label
+```

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -1,0 +1,148 @@
+# Dependencies
+
+## Internal Module Dependency Graph
+
+```
+run.sh
+ ├── cde_harvester
+ │    ├── ERDDAP.py               (HTTP client)
+ │    ├── dataset.py              (data model)
+ │    │    └── profiles.py        (profile stats)
+ │    ├── harvest_erddap.py       (orchestration)
+ │    │    ├── ERDDAP.py
+ │    │    ├── dataset.py
+ │    │    ├── CDEComplianceChecker.py
+ │    │    └── utils.py           (EOV mappings, CKAN)
+ │    ├── platform_ioos_to_l06.py (vocab mapping)
+ │    ├── output.py               (CSV writer)
+ │    └── __main__.py             (threading, queue, CLI)
+ │
+ └── cde_db_loader
+      ├── db_loader.py            (full reload)
+      ├── incremental_db_loader.py (incremental)
+      └── __main__.py             (CLI, strategy selection)
+
+download_scheduler
+ ├── download_scheduler.py
+ │    ├── downloader_wrapper      (from erddap_downloader package)
+ │    │    └── download_erddap.py
+ │    │         └── download_pdf.py (optional)
+ │    └── download_email.py
+ └── __main__.py
+
+web-api
+ ├── app.js
+ ├── db.js                        (Knex pool, used by all routes)
+ ├── cache.js                     (Redis, used by all routes)
+ └── routes/
+      ├── datasets.js
+      ├── tiles.js
+      ├── download.js
+      ├── downloadEstimate.js
+      ├── organizations.js
+      ├── oceanVariables.js
+      ├── platforms.js
+      ├── pointQuery.js
+      └── preview.js
+
+frontend
+ ├── Map.js                       (Mapbox GL)
+ ├── Filter.jsx                   (query state)
+ ├── DatasetsTable.jsx
+ ├── DownloadDetails.jsx
+ └── IntroModal.jsx
+```
+
+---
+
+## External Python Dependencies
+
+From `pyproject.toml` / `uv.lock`:
+
+| Package | Version | Used By | Purpose |
+|---------|---------|---------|---------|
+| pandas | ≥1.3 | harvester, db-loader | DataFrame operations, CSV I/O |
+| requests | ≥2.26 | harvester | HTTP calls to ERDDAP, CKAN |
+| erddapy | ≥1.0 | harvester | ERDDAP URL builder helpers |
+| PyYAML | ≥6.0 | harvester | Config file parsing |
+| diskcache | ≥5.0 | harvester | Disk-based HTTP response cache |
+| shapely | ≥1.8 | downloader | Polygon geometry + WKT parsing |
+| SQLAlchemy | ≥1.4 | db-loader | DB connection + ORM utilities |
+| psycopg2-binary | ≥2.9 | db-loader, scheduler | PostgreSQL driver |
+| loguru | ≥0.6 | harvester, scheduler | Structured logging |
+| sentry-sdk | ≥1.0 | harvester, scheduler | Error tracking |
+| tqdm | ≥4.0 | harvester | Progress bars |
+| Jinja2 | ≥3.0 | scheduler | Email HTML templating |
+| geopandas | optional | downloader | Spatial DataFrame operations |
+
+---
+
+## External Node.js Dependencies
+
+From `web-api/package.json`:
+
+| Package | Purpose |
+|---------|---------|
+| express | HTTP server framework |
+| knex | SQL query builder + connection pooling |
+| pg | PostgreSQL driver for Node.js |
+| ioredis | Redis client |
+| cache-manager | Unified cache abstraction |
+| cache-manager-ioredis | Redis backend for cache-manager |
+| cors | CORS middleware |
+| swagger-ui-express | API documentation UI |
+| express-validator | Request validation |
+| @sentry/node | Error tracking |
+| axios | HTTP client (for internal calls if any) |
+
+From `frontend/package.json`:
+
+| Package | Purpose |
+|---------|---------|
+| react | UI framework |
+| react-dom | DOM rendering |
+| mapbox-gl | Interactive map |
+| @mapbox/mapbox-gl-draw | Polygon/rectangle drawing tools |
+| i18next | Internationalisation |
+| react-i18next | React bindings for i18n |
+| webpack | Module bundler |
+| babel | JS transpiler |
+
+---
+
+## Shared Data Contracts
+
+These JSON files act as shared contracts between harvester and db-loader:
+
+| File | Location | Consumer |
+|------|----------|---------|
+| `datasets.csv` | `harvest/` folder | db-loader |
+| `profiles.csv` | `harvest/` folder | db-loader |
+| `variables.csv` | `harvest/` folder | db-loader |
+| `ckan.csv` | `harvest/` folder | db-loader |
+| `cde_to_goos_eov.json` | `harvester/cde_harvester/` | harvester (EOV mapping) |
+| `goos_eov_to_standard_name.json` | `harvester/cde_harvester/` | harvester (CF name mapping) |
+| `cioos_erddap_servers.csv` | `harvester/` | harvester (server list) |
+
+---
+
+## Database as Integration Bus
+
+PostgreSQL acts as the integration point between all services:
+
+```
+harvester/db-loader ──writes──► cde.datasets
+                                cde.profiles
+                                cde.organizations
+                                cde.variables
+                                cde.points
+                                cde.hexes_zoom_0/1
+
+web-api ──────────reads───────► all tables above
+        ──────writes──────────► cde.download_jobs
+
+download_scheduler ──reads/
+                     writes──► cde.download_jobs
+```
+
+No direct inter-service HTTP calls exist (other than to ERDDAP/CKAN). PostgreSQL is the single source of truth for all runtime state.

--- a/docs/execution_flow.md
+++ b/docs/execution_flow.md
@@ -1,0 +1,228 @@
+# Execution Flow
+
+## Entry Points
+
+| Entry Point | How Started | Purpose |
+|-------------|-------------|---------|
+| `harvester/run.sh` | cron job / manual | Trigger nightly harvest + DB load |
+| `python -m cde_harvester` | CLI / Docker | Harvest ERDDAP servers to CSVs |
+| `python -m cde_db_loader` | CLI / Docker | Load CSVs into PostgreSQL |
+| `python -m download_scheduler` | Docker / systemd | Poll and execute download jobs |
+| `node app.js` (web-api) | Docker | REST API server |
+| `webpack-dev-server` / Nginx | Docker | Frontend |
+
+---
+
+## Workflow A — Nightly Harvest + DB Load
+
+### Step-by-step
+
+```
+1. run.sh (cron, e.g. daily at 2am)
+   ├── sets LOG_DIR, CONFIG_FILE from env
+   ├── python -m cde_harvester -f harvest_config.yaml
+   │     └── see Harvester Flow below
+   └── python -m cde_db_loader --folder harvest [--incremental]
+         └── see DB Loader Flow below
+```
+
+### Harvester Flow
+
+```
+cde_harvester/__main__.py
+  │
+  ├── load harvest_config.yaml (erddap_urls, filters, cache settings)
+  ├── load EOV mappings (cde_to_goos_eov.json, goos_eov_to_standard_name.json)
+  ├── load platform mappings (platform_ioos_to_l06.py)
+  │     └── download from MMISW ontology or use cached CSV
+  │
+  ├── create ThreadPoolExecutor (max_workers from config)
+  ├── create Queue of ERDDAP server URLs
+  │
+  └── for each ERDDAP server URL (in parallel threads):
+        harvest_erddap.harvest_server(url, config)
+          │
+          ├── ERDDAP(url).get_dataset_list()
+          │     → GET /erddap/tabledap/allDatasets.csv
+          │     → returns list of dataset IDs
+          │
+          ├── for each dataset_id:
+          │     dataset.Dataset(erddap_client, dataset_id)
+          │       ├── fetch globals metadata   → /erddap/info/{id}/index.csv
+          │       ├── fetch variable metadata
+          │       ├── CDEComplianceChecker.check(dataset)
+          │       │     ├── has supported cf_role? (timeSeries/profile/trajectory)
+          │       │     ├── has at least one supported EOV variable?
+          │       │     └── not both depth AND altitude?
+          │       │
+          │       ├── [if compliant] profiles.get_profiles(dataset)
+          │       │     → GET /erddap/tabledap/{id}.csv?profile_id&time&depth&lat&lon
+          │       │     → extract min/max per profile
+          │       │
+          │       └── utils.get_ckan_record(globals)
+          │             → CKAN API lookup by organization name
+          │
+          └── output.write_csvs(folder)
+                → datasets.csv
+                → profiles.csv
+                → variables.csv
+                → ckan.csv
+```
+
+### DB Loader Flow
+
+#### Full Reload (default)
+
+```
+cde_db_loader/__main__.py
+  │
+  ├── connect to PostgreSQL (SQLAlchemy)
+  ├── DROP all foreign key constraints
+  ├── TRUNCATE cde.datasets, cde.profiles, cde.variables, cde.organizations, cde.points
+  │
+  ├── COPY datasets.csv   → cde.datasets_staging
+  ├── COPY profiles.csv   → cde.profiles_staging
+  ├── COPY variables.csv  → cde.variables_staging
+  ├── COPY ckan.csv       → cde.ckan_staging
+  │
+  ├── execute SQL: profile_process()
+  │     → deduplicates, links profiles to datasets
+  ├── execute SQL: ckan_process()
+  │     → upserts organizations, links to datasets
+  ├── execute SQL: create_hexes()
+  │     → builds hexes_zoom_0 and hexes_zoom_1 spatial aggregations
+  └── execute SQL: set_constraints()
+        → re-adds foreign key constraints
+```
+
+#### Incremental Mode (`--incremental` / `INCREMENTAL_MODE=true`)
+
+```
+cde_db_loader/__main__.py
+  │
+  ├── COPY CSVs → temporary staging tables
+  ├── UPSERT from staging → live tables (ON CONFLICT DO UPDATE)
+  ├── DELETE rows present in live tables but absent from staging
+  │     (these are datasets that disappeared from ERDDAP servers)
+  └── execute SQL: profile_process(), ckan_process(), create_hexes()
+```
+
+---
+
+## Workflow B — User Data Discovery (Runtime API)
+
+### Step-by-step
+
+```
+1. Browser loads frontend (served by Nginx)
+2. React app initialises:
+   ├── GET /api/oceanVariables  → loads EOV filter options
+   ├── GET /api/organizations   → loads org filter options
+   └── GET /api/platforms       → loads platform filter options
+
+3. User draws polygon on Mapbox map
+4. User selects time range, EOVs, platforms
+
+5. Frontend requests tile data:
+   GET /api/tiles?zoom=N&polygon=WKT&...
+     └── web-api routes/tiles.js
+           └── Knex query → PostGIS ST_Intersects on hexes_zoom_N
+               → returns GeoJSON hexagons with dataset counts
+
+6. Frontend requests dataset list:
+   GET /api/datasets?polygon=WKT&startDate=...&endDate=...&eov=...
+     └── web-api routes/datasets.js
+           └── Knex query → cde.datasets JOIN cde.profiles
+               → filter by spatial, temporal, EOV
+               → returns paginated JSON
+
+7. Results displayed in table and map
+```
+
+---
+
+## Workflow C — User Data Download
+
+### Step-by-step
+
+```
+1. User selects datasets + clicks Download
+2. Frontend:
+   GET /api/downloadEstimate?...   → check size before committing
+   POST /api/download              → { polygon, startDate, endDate, email, datasets }
+     └── web-api routes/download.js
+           └── INSERT INTO cde.download_jobs (status='open', query_params)
+               → returns job_id
+
+3. download_scheduler polling loop (runs every N seconds):
+   download_scheduler.py
+     ├── SELECT * FROM cde.download_jobs WHERE status='open'
+     │     FOR UPDATE SKIP LOCKED   (safe for multiple scheduler replicas)
+     ├── UPDATE status = 'in_progress'
+     │
+     ├── downloader_wrapper.run_download_query(job)
+     │     │
+     │     ├── create temp directory
+     │     ├── download_erddap.run(query_params)
+     │     │     ├── for each dataset_id in job:
+     │     │     │     ├── build ERDDAP tabledap URL with time/bbox constraints
+     │     │     │     ├── GET /erddap/tabledap/{id}.csv (streaming)
+     │     │     │     ├── if polygon (not just bbox): filter rows with Shapely
+     │     │     │     ├── check size limits (1GB/dataset, 5GB/total)
+     │     │     │     └── write to temp/{dataset_id}.csv
+     │     │     └── return file list + metadata
+     │     │
+     │     ├── zip all files → downloads/{job_id}.zip
+     │     └── cleanup temp dir
+     │
+     ├── UPDATE cde.download_jobs SET status='completed', download_url=...
+     │
+     └── download_email.send(user_email, download_url)
+           └── Gmail SMTP → HTML email with link
+
+4. User receives email with download link
+   → Nginx serves /downloads/{job_id}.zip from named volume
+```
+
+---
+
+## Execution Tree
+
+```
+run.sh
+├── cde_harvester.__main__
+│   ├── harvest_erddap.harvest_server (×N threads)
+│   │   ├── ERDDAP.get_dataset_list
+│   │   ├── dataset.Dataset (×M datasets)
+│   │   │   ├── ERDDAP.get_metadata
+│   │   │   ├── CDEComplianceChecker.check
+│   │   │   ├── profiles.get_profiles
+│   │   │   └── utils.get_ckan_record
+│   │   └── output.write_csvs
+│   └── [exit]
+│
+└── cde_db_loader.__main__
+    ├── db_loader.full_reload      (or incremental_db_loader)
+    │   ├── COPY CSV files
+    │   └── SQL: profile_process, ckan_process, create_hexes, set_constraints
+    └── [exit]
+
+web-api/app.js (always-on)
+└── routes/: datasets, tiles, download, organizations, ...
+    └── db.js (Knex) → PostgreSQL
+
+download_scheduler.__main__ (always-on polling loop)
+└── download_scheduler.run_pending_jobs
+    ├── downloader_wrapper.run_download_query
+    │   └── download_erddap.run
+    └── download_email.send
+```
+
+---
+
+## Runtime Lifecycle Notes
+
+- **Harvester** is stateless; safe to re-run. Uses disk-cache to avoid re-fetching unchanged ERDDAP metadata.
+- **DB Loader** is idempotent in full-reload mode. Incremental mode tracks deletions via set-difference between staging and live tables.
+- **Download Scheduler** uses `FOR UPDATE SKIP LOCKED` so multiple replicas never double-process a job.
+- **Web API** is stateless; Redis cache is invalidated by TTL, not events (cache drift is acceptable since data is updated nightly).

--- a/docs/harvest_validator.md
+++ b/docs/harvest_validator.md
@@ -1,0 +1,296 @@
+# Harvest Validator
+
+A run-time validation tool that instruments a live harvest, captures every log message, HTTP call, and data-transformation event, then produces a per-run report surfacing failures, data-quality issues, unhandled error conditions, and performance anomalies.
+
+---
+
+## Directory Structure
+
+```
+harvester/harvest_validator/
+├── __init__.py       Exports HarvestRunner, analyze, ReportWriter
+├── __main__.py       Full CLI  (python -m harvest_validator -f config.yaml)
+├── collectors.py     LogCapture (logging handler) + HttpCallTracker (HTTP interceptor)
+├── runner.py         HarvestRunner orchestrator + HarvestArtifacts data class
+├── analyzers.py      17 check functions → HarvestAnalysis with ranked findings
+├── reporter.py       ReportWriter: writes report.md / report.json / events.jsonl
+└── quick_check.py    Fast smoke-test runner with optional ERDDAP + dataset args
+```
+
+---
+
+## Usage
+
+### Quick check — offline (no network, verifies the tool itself is healthy)
+
+```bash
+python -m harvest_validator.quick_check
+```
+
+### Quick check — real ERDDAP server, all datasets
+
+```bash
+python -m harvest_validator.quick_check \
+    --erddap https://data.cioospacific.ca/erddap
+```
+
+### Quick check — single dataset (fastest spot-check)
+
+```bash
+python -m harvest_validator.quick_check \
+    --erddap https://catalogue.hakai.org/erddap \
+    --dataset HakaiKCBuoyResearch
+```
+
+### Full production run via the main CLI
+
+```bash
+# Reads erddap_urls from the config file, runs all servers
+python -m harvest_validator -f harvest_config.yaml
+
+# Write reports to a custom directory
+python -m harvest_validator -f harvest_config.yaml --output-dir /data/reports
+
+# Override the auto-generated run ID
+python -m harvest_validator -f harvest_config.yaml --run-id nightly_20260602
+```
+
+### CLI options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `-f / --file` | *(required)* | Path to `harvest_config.yaml` |
+| `--output-dir` | `./validation_reports` | Base directory for report output |
+| `--run-id` | `YYYYMMDD_HHMMSS` | Override the auto-generated run ID |
+| `--format` | `all` | `all` writes all three files; `md` or `json` for one only |
+
+### `quick_check.py` options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--erddap` | *(offline mock)* | ERDDAP base URL to validate against |
+| `--dataset` | *(all datasets)* | Limit to one dataset ID for a faster spot-check |
+| `--output-dir` | `./validation_reports` | Base directory for report output |
+| `--no-cache` | `False` | Disable disk cache during the run |
+
+### Exit codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | Run completed; no CRITICAL or HIGH findings detected |
+| `1` | Run completed; at least one CRITICAL or HIGH finding detected |
+| `2` | Tool itself failed (bad config, verification error, import error) |
+
+---
+
+## What the Tool Captures
+
+Both collectors are context managers. They install themselves before the harvest starts and restore original state afterwards, making them transparent to the source code under observation.
+
+### `LogCapture` — `collectors.py`
+
+**Mechanism:** Installs as a root-level `logging.Handler` at `DEBUG` level.
+
+**Captures per event:**
+
+| Field | Description |
+|-------|-------------|
+| `time` | ISO 8601 timestamp |
+| `level` | `DEBUG` / `INFO` / `WARNING` / `ERROR` / `CRITICAL` |
+| `logger` | Logger name (usually the ERDDAP domain or module path) |
+| `message` | Formatted log message |
+| `exc_info` | Full stack trace if an exception was attached |
+
+All records are written to `events.jsonl` (one JSON object per line) and used by the analyzer to detect patterns in warnings and errors.
+
+### `HttpCallTracker` — `collectors.py`
+
+**Mechanism:** Monkey-patches `requests.Session.get` at the class level. Thread-safe via a lock; the harvester runs worker threads concurrently.
+
+**Captures per call:**
+
+| Field | Description |
+|-------|-------------|
+| `url` | Full request URL |
+| `server` | Hostname extracted from the URL |
+| `status` | HTTP status code; `None` if a connection-level error occurred |
+| `elapsed_s` | Wall-clock time from request start to response receipt |
+| `size_bytes` | Length of the response body in bytes |
+| `ok` | `True` only when `status == 200` |
+| `redirected_to` | Destination URL if the server redirected (EDDTableFromErddap) |
+| `error` | Exception message when no HTTP response was received |
+
+---
+
+## Analyzer Detection
+
+The analyzer (`analyzers.py`) runs 17 check functions against the collected artifacts. Every finding has a severity, category, human-readable title, detail text, and an optional list of affected dataset or server IDs.
+
+### Severity levels
+
+| Severity | Meaning | Exit code impact |
+|----------|---------|-----------------|
+| `CRITICAL` | Pipeline is broken or output is entirely unusable | exit 1 |
+| `HIGH` | Significant data loss or unhandled exceptions | exit 1 |
+| `MEDIUM` | Partial data loss or known compatibility gaps | exit 0 |
+| `LOW` | Minor quality warnings or vocabulary mismatches | exit 0 |
+| `INFO` | Coverage gaps and informational observations | exit 0 |
+
+### Finding categories
+
+| Category | Severity | Trigger condition |
+|----------|----------|-------------------|
+| **Fatal Error** | CRITICAL | A top-level unhandled exception terminated the harvest loop |
+| **Server Unreachable** | CRITICAL | Every HTTP call to an ERDDAP server failed |
+| **Empty Output** | CRITICAL | No datasets harvested despite no fatal error |
+| **Empty Output** | HIGH | Datasets found but zero profiles extracted |
+| **Unhandled Exception** | HIGH | Datasets with `UNKNOWN_ERROR` reason code; stack traces in log |
+| **HTTP Error** | HIGH | HTTP 5xx responses or connection errors |
+| **HTTP Error** | MEDIUM | HTTP 4xx responses |
+| **Data Integrity** | HIGH | `time_min > time_max` in profiles; null mandatory columns |
+| **Data Integrity** | MEDIUM | `depth_min > depth_max`; duplicate `dataset_id` rows; empty `eovs` list on harvested datasets; `n_records ≤ 0` |
+| **Compatibility** | MEDIUM | `orderByCount` unsupported on older ERDDAP server versions (record counts will be null) |
+| **Size Limit** | MEDIUM | Response at or over the 200 MB cap; dataset skipped |
+| **Data Quality** | MEDIUM | Bad-geometry filter removed profiles (lat/lon out of range, depth > 15,000 m) |
+| **Data Quality** | MEDIUM | Compliant datasets produced zero profiles after extraction |
+| **Data Quality** | LOW | Profiles with non-unique lat/lon for the same profile ID |
+| **Partial Data** | LOW | `orderByCount` HTTP errors; `n_records` will be null for affected datasets |
+| **Vocabulary** | LOW | IOOS or L06 platform codes not found in the vocabulary mapping |
+| **Performance** | LOW | HTTP requests exceeding 30 s; responses exceeding 150 MB |
+| **Coverage Gap** | INFO | CF standard names present in the data but unmapped to any CDE EOV |
+
+### Summary objects included alongside findings
+
+In addition to the ranked findings list, the analysis includes:
+
+- **`skip_breakdown`** — per reason-code breakdown: count, percentage of total skipped, up to 5 example dataset IDs, and a plain-English description of the reason
+- **`http_summary`** — total calls, success/error counts, average and max response time, total MB transferred, error breakdown by HTTP status, list of servers contacted
+- **`log_summary`** — count of events at each level (DEBUG / INFO / WARNING / ERROR / CRITICAL)
+- **`data_summary`** — servers configured, servers with results, datasets harvested/skipped/total, profiles extracted
+- **`per_server_summary`** — per ERDDAP URL: datasets harvested, datasets skipped, profiles extracted
+- **`error_log_lines`** — verbatim ERROR and CRITICAL log lines (with stack traces) included in the Markdown report
+
+---
+
+## Per-Run Report Output
+
+Each run writes three files to `<output-dir>/<run-id>/`:
+
+```
+validation_reports/
+└── 20260602_143022/
+    ├── report.md      Human-readable Markdown report
+    ├── report.json    Machine-readable structured data
+    └── events.jsonl   Full log event stream (one JSON object per line)
+```
+
+### `report.md` — Markdown sections
+
+| Section | Contents |
+|---------|----------|
+| Header | Run ID, start/end times, duration, config summary |
+| Executive Summary | Metrics table (datasets, profiles, HTTP calls, errors) + finding count by severity |
+| Findings | Severity-grouped findings with detail text and affected IDs |
+| Skip Analysis | Reason-code breakdown table + example dataset IDs per reason |
+| Per-Server Breakdown | Harvested / skipped / profiles per ERDDAP server |
+| HTTP API Calls | Call counts, error rate, timing stats, per-status error breakdown, server list |
+| Log Event Summary | Record count per log level |
+| Error Log Entries | Verbatim ERROR/CRITICAL log lines (capped at 200; remainder in events.jsonl) |
+
+### `report.json` — Required top-level keys
+
+```json
+{
+  "run_id": "20260602_143022",
+  "start_time": "2026-06-02T14:30:22",
+  "end_time": "2026-06-02T14:45:54",
+  "duration_s": 932.1,
+  "duration_human": "15m 32s",
+  "config_summary": { "erddap_server_count": 5, "cache_enabled": false, ... },
+  "findings": [ { "severity": "HIGH", "category": "...", "title": "...", "detail": "...", "affected": [...], "count": 3 } ],
+  "skip_breakdown": [ { "reason_code": "CDM_DATA_TYPE_UNSUPPORTED", "count": 89, "pct": 48.6, "examples": [...], "description": "..." } ],
+  "http_summary": { "total": 2542, "success": 2476, "errors": 66, "avg_elapsed_s": 1.23, ... },
+  "log_summary": { "DEBUG": 8432, "INFO": 1204, "WARNING": 89, "ERROR": 52, "CRITICAL": 0 },
+  "data_summary": { "datasets_harvested": 612, "datasets_skipped": 183, "profiles_extracted": 14203, ... },
+  "per_server_summary": { "data.cioospacific.ca": { "datasets_harvested": 120, ... } },
+  "error_log_lines": [ "[14:32:15] ERROR | ... | ..." ]
+}
+```
+
+### `events.jsonl` — Log event stream
+
+One JSON object per line. Each object has: `time`, `level`, `logger`, `message`, `exc_info` (null unless an exception was attached).
+
+```jsonl
+{"time": "2026-06-02T14:30:24", "level": "INFO", "logger": "data.cioospacific.ca", "message": "Found 147 datasets", "exc_info": null}
+{"time": "2026-06-02T14:32:15", "level": "ERROR", "logger": "data.cioospacific.ca - bad_ds", "message": "HTTP ERROR: 500 Internal Server Error", "exc_info": "Traceback (most recent call last):\n  ..."}
+```
+
+### Report self-verification
+
+Before `ReportWriter.write()` returns, it re-reads all three output files and asserts:
+
+- `report.json` parses as valid JSON and contains all required top-level keys
+- Every finding object has `severity`, `category`, `title`, and `detail` fields
+- `data_summary` contains all required sub-keys
+- Finding count in the file matches the in-memory analysis object
+- `report.md` contains the required section headers
+- `events.jsonl` has exactly as many lines as log records were captured, and every line is valid JSON with `time`, `level`, `logger`, `message` fields
+
+A structural violation raises `ValueError` and the tool exits with code 2, preventing a silently corrupt report from being treated as valid.
+
+---
+
+## Architecture Overview
+
+```
+harvest_config.yaml
+        │
+        ▼
+  HarvestRunner.run()           ← runner.py
+        │
+        ├── LogCapture (enters)        intercepts root logger
+        ├── HttpCallTracker (enters)   patches requests.Session.get
+        │
+        ├── harvest_erddap() × N       real production harvest code
+        │       ↓ per server
+        │   [profiles_df, datasets_df, variables_df, skipped_df]
+        │
+        ├── HttpCallTracker (exits)    restores original Session.get
+        └── LogCapture (exits)         removes handler
+                │
+                ▼
+        HarvestArtifacts               runner.py
+          profiles, datasets,
+          variables, skipped,
+          log_capture, http_tracker,
+          per_server, fatal_error
+                │
+                ▼
+        analyze(artifacts)             analyzers.py
+          17 check functions
+                │
+                ▼
+        HarvestAnalysis                analyzers.py
+          findings (ranked),
+          skip_breakdown,
+          http_summary,
+          log_summary,
+          data_summary
+                │
+                ▼
+        ReportWriter.write()           reporter.py
+          report.md
+          report.json
+          events.jsonl
+          + self-verification
+```
+
+---
+
+## See Also
+
+- [docs/technical_debt.md](technical_debt.md) — Known bugs and unhandled conditions the validator is designed to surface
+- [docs/execution_flow.md](execution_flow.md) — How the harvest pipeline works end-to-end
+- [docs/data_flow.md](data_flow.md) — Data transformations the validator monitors
+- [docs/tests.md](tests.md) — The separate pytest-based unit and integration test suite

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -1,0 +1,197 @@
+# External Integrations
+
+## Integration Inventory
+
+---
+
+### 1. ERDDAP Servers
+
+**Purpose:** Primary data source. All ocean science datasets live on ERDDAP servers operated by various Canadian institutions.
+
+**Files Involved:**
+- `harvester/cde_harvester/ERDDAP.py` — HTTP client
+- `harvester/cde_harvester/harvest_erddap.py` — discovery orchestration
+- `downloader/erddap_downloader/download_erddap.py` — data download
+- `harvester/cioos_erddap_servers.csv` — list of known server URLs
+
+**Authentication:** None (public read-only endpoints)
+
+**Data Exchanged:**
+
+| Endpoint | Method | Purpose |
+|----------|--------|---------|
+| `/erddap/tabledap/allDatasets.csv` | GET | List all dataset IDs on a server |
+| `/erddap/info/{dataset_id}/index.csv` | GET | Dataset metadata (globals, variables, attributes) |
+| `/erddap/tabledap/{dataset_id}.csv?{query}` | GET | Profile IDs, stats, or actual data rows |
+
+**Caching:** `diskcache` (Python) caches ERDDAP metadata responses on disk. Toggle via `cache: true` in `harvest_config.yaml`. Prevents hammering servers on repeated test runs.
+
+**Known Servers (from `cioos_erddap_servers.csv`):**
+- CIOOS Pacific ERDDAP
+- CIOOS Atlantic ERDDAP
+- CIOOS St. Lawrence ERDDAP
+- Other institutional ERDDAP servers listed in the CSV
+
+---
+
+### 2. CKAN
+
+**Purpose:** Provides organizational/publisher metadata (organization name, logo URL, description, color) for datasets discovered during harvest.
+
+**Files Involved:**
+- `harvester/cde_harvester/utils.py` — `get_ckan_record()` function
+
+**Authentication:** None (public CKAN API)
+
+**Data Exchanged:**
+- Input: dataset global attribute `publisher_name` or `institution`
+- Output: organization record (name, title, image_url, color, description)
+
+**Endpoint:** CKAN action API — `GET /api/3/action/organization_show?id={org_name}`
+
+**Error Handling:** If CKAN lookup fails, the dataset is still harvested with empty organization data.
+
+---
+
+### 3. PostgreSQL 13 + PostGIS 3.1
+
+**Purpose:** Central data store for all harvested metadata, spatial aggregations, and download job queue.
+
+**Files Involved:**
+- `database/1_schema.sql` — schema definition
+- `database/2_functions.sql` — SQL processing functions
+- `db-loader/cde_db_loader/` — load logic
+- `web-api/db.js` — Knex connection pool
+- `download_scheduler/download_scheduler.py` — job polling
+
+**Authentication:** Username/password via environment variables (`DB_USER`, `DB_PASSWORD`)
+
+**Connection Details:**
+- Default port: 5432
+- Schema: `cde`
+- Harvester uses `DB_HOST_EXTERNAL` (bypasses Docker network)
+- All other services use `DB_HOST` (internal Docker DNS)
+
+**Key Tables:**
+
+| Table | Row Count Estimate | Description |
+|-------|--------------------|-------------|
+| `cde.datasets` | ~500–2000 | One row per ERDDAP dataset |
+| `cde.profiles` | ~10k–100k | One row per profile/timeseries |
+| `cde.variables` | ~5k–20k | One row per variable per dataset |
+| `cde.organizations` | ~50 | CKAN organization records |
+| `cde.points` | ~50k–500k | Unique lat/lon pairs |
+| `cde.hexes_zoom_0` | ~1k | Low-zoom hexagon tiles |
+| `cde.hexes_zoom_1` | ~10k | High-zoom hexagon tiles |
+| `cde.download_jobs` | growing | User download job queue |
+
+---
+
+### 4. Redis
+
+**Purpose:** API response cache to reduce database load.
+
+**Files Involved:**
+- `web-api/cache.js` — cache setup
+- `web-api/routes/*.js` — cache middleware wrapping route handlers
+
+**Authentication:** None (private Docker network, no password in dev)
+
+**Cache Strategy:**
+- TTL: 5 minutes (approximate; configurable)
+- Key: hash of full request URL + query params
+- Invalidation: TTL expiry only (no event-driven invalidation)
+- Production only: not used in development (`REDIS_HOST` env var controls activation)
+
+---
+
+### 5. Gmail SMTP
+
+**Purpose:** Delivers download completion emails to users.
+
+**Files Involved:**
+- `download_scheduler/download_email.py`
+- `download_scheduler/templates/` — Jinja2 HTML email templates
+
+**Authentication:** Gmail app password via `GMAIL_USER` / `GMAIL_PASSWORD` environment variables
+
+**Data Exchanged:**
+- To: user email address (from download job)
+- Subject: "Your CIOOS download is ready"
+- Body: HTML email with download link and dataset summary
+
+**Optional:** If `GMAIL_USER` is not set, email sending is skipped (job still completes).
+
+---
+
+### 6. MMISW Ontology (ioos.us)
+
+**Purpose:** Platform vocabulary — maps IOOS platform codes to NERC L06 codes used for platform-type filtering.
+
+**Files Involved:**
+- `harvester/cde_harvester/platform_ioos_to_l06.py`
+
+**Authentication:** None (public)
+
+**Endpoint:** `https://mmisw.org/ont/api/v0/mapping?...`
+
+**Caching:** Downloaded mapping is cached as a CSV file locally. If download fails, falls back to the cached CSV.
+
+---
+
+### 7. Sentry
+
+**Purpose:** Error and exception tracking in production.
+
+**Files Involved:**
+- `harvester/cde_harvester/__main__.py` — `sentry_sdk.init()`
+- `download_scheduler/__main__.py` — `sentry_sdk.init()`
+- `web-api/app.js` — Sentry Express middleware
+
+**Authentication:** DSN token via `SENTRY_DSN` environment variable
+
+**Data Exchanged:** Unhandled exceptions + stack traces → Sentry cloud
+
+---
+
+### 8. Nginx
+
+**Purpose:** Reverse proxy routing traffic to web-api, serving the frontend SPA, and serving completed download ZIP files.
+
+**Files Involved:**
+- `nginx/nginx.conf` — routing configuration
+- `docker-compose.yaml` / `docker-compose.production.yaml` — volume mounts
+
+**Routing:**
+- `/api/*` → web-api (upstream, load-balanced in production)
+- `/downloads/*` → named volume (`downloads`) containing ZIP files
+- `/*` → frontend static assets
+
+---
+
+### 9. Docker / Docker Compose
+
+**Purpose:** Service orchestration for all components.
+
+**Files Involved:**
+- `docker-compose.yaml` — development
+- `docker-compose.production.yaml` — production
+
+**Named Volumes:**
+- `db-data` — PostgreSQL data directory
+- `downloads` — completed ZIP files (shared between scheduler and nginx)
+- `cache` — harvester disk cache
+- `logs` — harvester logs
+
+---
+
+### 10. 1Password (Production Secrets)
+
+**Purpose:** Secrets management for production `.env` files.
+
+**Files Involved:**
+- `.env.production` — contains `op://vault/item/field` references
+
+**Pattern:** `op run --env-file .env.production -- docker compose up`
+
+The `op` CLI resolves secrets at container startup; no plaintext credentials are stored in the repo.

--- a/docs/onboarding_guide.md
+++ b/docs/onboarding_guide.md
@@ -1,0 +1,149 @@
+# Onboarding Guide
+
+## Recommended Reading Order
+
+Work through the files below in sequence. Each step builds context for the next.
+
+---
+
+### Step 1 — Understand the Problem Domain
+
+**Read:** [docs/repository_summary.md](repository_summary.md)
+
+Answers: what does this platform do, why does it exist, and what are the three core workflows.
+
+---
+
+### Step 2 — Understand the Data Model
+
+**Read:** [database/1_schema.sql](../database/1_schema.sql)
+
+The schema is the shared contract between all services. Before touching any Python or JavaScript code, understand:
+- What a `dataset` is vs a `profile` vs a `point`
+- What `hexes_zoom_0` and `hexes_zoom_1` are (pre-computed spatial aggregations)
+- What columns `download_jobs` has and what the `status` lifecycle is
+
+**Also read:** [database/2_functions.sql](../database/2_functions.sql)
+
+The SQL functions `profile_process()`, `ckan_process()`, and `create_hexes()` are where the heavy data transformation happens after CSV load.
+
+---
+
+### Step 3 — Understand the Harvest Pipeline
+
+**Read in order:**
+
+1. [harvester/cde_harvester/__main__.py](../harvester/cde_harvester/__main__.py) — CLI entry point, threading setup
+2. [harvester/cde_harvester/harvest_erddap.py](../harvester/cde_harvester/harvest_erddap.py) — per-server orchestration
+3. [harvester/cde_harvester/ERDDAP.py](../harvester/cde_harvester/ERDDAP.py) — ERDDAP HTTP client
+4. [harvester/cde_harvester/dataset.py](../harvester/cde_harvester/dataset.py) — Dataset class (metadata model)
+5. [harvester/cde_harvester/CDEComplianceChecker.py](../harvester/cde_harvester/CDEComplianceChecker.py) — validation rules
+6. [harvester/cde_harvester/profiles.py](../harvester/cde_harvester/profiles.py) — profile stat extraction
+7. [harvester/cde_harvester/utils.py](../harvester/cde_harvester/utils.py) — EOV/CKAN helpers
+8. [harvester/cde_harvester/output.py](../harvester/cde_harvester/output.py) — CSV writer
+
+At this point you understand what data enters the system and why some datasets are excluded.
+
+---
+
+### Step 4 — Understand DB Loading
+
+**Read:**
+
+1. [db-loader/cde_db_loader/__main__.py](../db-loader/cde_db_loader/__main__.py) — entry point, strategy selection
+2. [db-loader/cde_db_loader/db_loader.py](../db-loader/cde_db_loader/db_loader.py) — full reload path
+3. [db-loader/cde_db_loader/incremental_db_loader.py](../db-loader/cde_db_loader/incremental_db_loader.py) — incremental path
+
+At this point you understand the full harvest → load → database cycle.
+
+---
+
+### Step 5 — Understand the API
+
+**Read:**
+
+1. [web-api/app.js](../web-api/app.js) — Express setup, middleware stack
+2. [web-api/db.js](../web-api/db.js) — database connection pool
+3. [web-api/routes/datasets.js](../web-api/routes/datasets.js) — most complex route
+4. [web-api/routes/tiles.js](../web-api/routes/tiles.js) — spatial hex queries
+5. [web-api/routes/download.js](../web-api/routes/download.js) — job insertion
+
+At this point you understand how the database is exposed to the frontend.
+
+---
+
+### Step 6 — Understand the Download Pipeline
+
+**Read:**
+
+1. [download_scheduler/download_scheduler.py](../download_scheduler/download_scheduler.py) — job lifecycle
+2. [downloader/erddap_downloader/downloader_wrapper.py](../downloader/erddap_downloader/downloader_wrapper.py) — wrapper
+3. [downloader/erddap_downloader/download_erddap.py](../downloader/erddap_downloader/download_erddap.py) — ERDDAP queries + polygon filter
+4. [download_scheduler/download_email.py](../download_scheduler/download_email.py) — email delivery
+
+---
+
+### Step 7 — Understand the Frontend
+
+**Read:**
+
+1. [frontend/src/Map.js](../frontend/src/Map.js) — Mapbox integration, draw tools
+2. [frontend/src/Filter.jsx](../frontend/src/Filter.jsx) — query state management
+3. [frontend/src/DatasetsTable.jsx](../frontend/src/DatasetsTable.jsx) — results display
+4. [frontend/src/DownloadDetails.jsx](../frontend/src/DownloadDetails.jsx) — download form
+
+---
+
+### Step 8 — Understand the Configuration
+
+**Read:** [docs/configuration.md](configuration.md)
+
+Then look at `docker-compose.yaml` to see how env vars flow into containers.
+
+---
+
+### Step 9 — Run It Locally
+
+```bash
+# 1. Copy environment file
+cp .env.example .env
+# Edit .env: set DB_NAME, DB_USER, DB_PASSWORD, API_URL, BASE_URL
+
+# 2. Start core services
+docker compose up db web-api nginx frontend
+
+# 3. Run a test harvest (small config)
+cp harvest_config.test.yaml harvest_config.yaml
+docker compose run --rm harvester python -m cde_harvester -f harvest_config.yaml
+
+# 4. Load harvested data
+docker compose run --rm db-loader python -m cde_db_loader --folder harvest
+
+# 5. Open browser at http://localhost
+```
+
+---
+
+### Step 10 — Read the Technical Debt Document
+
+**Read:** [docs/technical_debt.md](technical_debt.md)
+
+Understand the known risks before making changes — especially around full-reload atomicity and the download retry gap.
+
+---
+
+## Key Concepts Glossary
+
+| Term | Meaning |
+|------|---------|
+| ERDDAP | Scientific data server software; provides REST API for ocean datasets |
+| EOV | Essential Ocean Variable — standardized names for ocean measurements (e.g., "Sea Surface Temperature") |
+| CF standard name | Climate and Forecast convention variable name (e.g., `sea_water_temperature`) |
+| GOOS EOV | Global Ocean Observing System EOV classification |
+| cf_role | ERDDAP attribute indicating dataset type: `timeSeries`, `profile`, or `trajectory` |
+| Profile | A single vertical cast or time-series at a fixed location |
+| Hexes | Pre-computed hexagonal spatial bins for fast map tile rendering |
+| CKAN | Open data portal software; used here as an organization registry |
+| NERC L06 | BODC SeaVoX Platform Categories vocabulary (platform type codes) |
+| IOOS | Integrated Ocean Observing System platform type codes |
+| Incremental mode | DB load strategy that only updates changed records (vs full truncate + reload) |

--- a/docs/repository_summary.md
+++ b/docs/repository_summary.md
@@ -1,0 +1,121 @@
+# Repository Summary — explore-cioos
+
+> **Start here.** This document answers the key questions a new engineer needs before diving into the codebase.
+
+---
+
+## 1. What does this repository actually do?
+
+**explore-cioos** is a full-stack data discovery and download platform for Canadian ocean science data. It allows researchers to:
+
+1. Visually explore ocean datasets on an interactive map
+2. Filter by time range, geographic polygon, platform type, and ocean variable (EOV)
+3. Download the resulting data as zipped NetCDF/CSV files delivered by email
+
+---
+
+## 2. What problem does it solve?
+
+Ocean science data in Canada is distributed across dozens of ERDDAP servers operated by different institutions. There is no single interface to search, filter, and download across all of them. This platform:
+
+- **Harvests** dataset metadata from all known ERDDAP servers nightly
+- **Indexes** that metadata into a spatial PostgreSQL/PostGIS database
+- **Serves** it through a REST API and React frontend
+- **Executes** user-requested downloads against the original ERDDAP servers and delivers results by email
+
+---
+
+## 3. What are the core workflows?
+
+### Workflow A — Nightly Data Harvest
+```
+run.sh (cron)
+  → cde_harvester (__main__.py)
+      → query each ERDDAP server (ERDDAP.py)
+      → validate datasets (CDEComplianceChecker.py)
+      → extract metadata + profile stats (dataset.py, profiles.py)
+      → write CSVs (datasets.csv, profiles.csv, variables.csv, ckan.csv)
+  → cde_db_loader (__main__.py)
+      → load CSVs into PostgreSQL (incremental or full reload)
+      → run SQL processing (profile_process, create_hexes, etc.)
+```
+
+### Workflow B — User Data Discovery
+```
+Frontend (React + Mapbox)
+  → draw polygon / select filters
+  → GET /tiles, /datasets, /oceanVariables (web-api Express)
+      → Knex queries → PostgreSQL
+      → Redis cache (production)
+  → display results on map and table
+```
+
+### Workflow C — User Data Download
+```
+Frontend
+  → POST /download (web-api)
+      → insert row into cde.download_jobs
+  → download_scheduler (polling loop)
+      → pick up "open" job
+      → downloader_wrapper.run_download_query()
+          → erddap_downloader: fetch data from ERDDAP servers
+          → apply polygon filter, size limits, zip
+      → update job status in DB
+      → email user download link (Gmail SMTP)
+```
+
+---
+
+## 4. What systems does it depend on?
+
+| System | Role |
+|--------|------|
+| ERDDAP servers (external) | Source of all ocean datasets |
+| PostgreSQL 13 + PostGIS 3.1 | Spatial data store |
+| CKAN (external) | Organization/publisher metadata |
+| Redis | API response caching (production only) |
+| Gmail SMTP | Download completion email delivery |
+| Nginx | Reverse proxy + static file serving |
+| Docker Compose | Service orchestration |
+
+---
+
+## 5. What would break if key modules failed?
+
+| Module | Impact |
+|--------|--------|
+| `harvester` | Dataset index goes stale; no new datasets appear |
+| `db-loader` | Harvested CSVs don't reach the database |
+| `web-api` | Frontend shows nothing; downloads cannot be requested |
+| `download_scheduler` | Downloads queue up but are never executed; no emails sent |
+| `PostgreSQL` | Entire platform is down |
+| ERDDAP servers | Harvest fails for those servers; downloads fail for their datasets |
+
+---
+
+## 6. Most important files to understand first
+
+| File | Why |
+|------|-----|
+| [harvester/cde_harvester/__main__.py](../harvester/cde_harvester/__main__.py) | Harvest orchestration and threading |
+| [harvester/cde_harvester/harvest_erddap.py](../harvester/cde_harvester/harvest_erddap.py) | Dataset discovery and compliance filtering |
+| [harvester/cde_harvester/ERDDAP.py](../harvester/cde_harvester/ERDDAP.py) | ERDDAP API client |
+| [harvester/cde_harvester/dataset.py](../harvester/cde_harvester/dataset.py) | Dataset metadata model |
+| [db-loader/cde_db_loader/__main__.py](../db-loader/cde_db_loader/__main__.py) | DB load orchestration |
+| [database/1_schema.sql](../database/1_schema.sql) | Core schema (understand data model here) |
+| [web-api/routes/](../web-api/routes/) | All REST API endpoints |
+| [download_scheduler/download_scheduler.py](../download_scheduler/download_scheduler.py) | Download job lifecycle |
+| [downloader/erddap_downloader/download_erddap.py](../downloader/erddap_downloader/download_erddap.py) | ERDDAP download logic |
+
+---
+
+## See Also
+
+- [Architecture](architecture.md) — Layer diagrams and component catalog
+- [Execution Flow](execution_flow.md) — Step-by-step runtime walkthrough
+- [Data Flow](data_flow.md) — How data moves through the system
+- [Configuration](configuration.md) — All config variables and sources
+- [Integrations](integrations.md) — External system details
+- [Dependencies](dependencies.md) — Internal and external dependency graphs
+- [Technical Debt](technical_debt.md) — Risk assessment
+- [Onboarding Guide](onboarding_guide.md) — Recommended reading order for new engineers

--- a/docs/technical_debt.md
+++ b/docs/technical_debt.md
@@ -1,0 +1,157 @@
+# Technical Debt Assessment
+
+---
+
+## High Risk
+
+### 1. No Integration Tests for ETL Pipeline
+
+**Location:** `harvester/`, `db-loader/`
+
+The harvest → load pipeline has no automated tests verifying the full cycle end-to-end. The compliance checker and profile extraction logic are tested only manually (or by running against live ERDDAP servers). A regression in `CDEComplianceChecker.py` or `profiles.py` could silently discard large numbers of datasets.
+
+**Risk:** Silent data quality regression on any code change.
+
+**Mitigation needed:** Fixture-based unit tests with recorded ERDDAP API responses.
+
+---
+
+### 2. Download Scheduler Has No Retry Logic
+
+**Location:** `download_scheduler/download_scheduler.py`
+
+If a download job fails due to a transient ERDDAP timeout or network error, the job is marked `failed` immediately with no retry. Users must re-submit their request manually.
+
+**Risk:** Poor user experience; transient failures appear as permanent.
+
+**Mitigation needed:** Retry counter column in `download_jobs`, exponential backoff.
+
+---
+
+### 3. Full Reload Drops All Constraints Mid-Load
+
+**Location:** `db-loader/cde_db_loader/db_loader.py`
+
+The full-reload path drops foreign key constraints before loading, leaving the database in an unconstrained state during the entire load window. If the process crashes mid-load, the database is left with orphaned rows and no constraints.
+
+**Risk:** Data integrity loss if load is interrupted; no atomic transaction wrapper.
+
+**Mitigation needed:** Wrap full reload in a transaction, or always use incremental mode in production.
+
+---
+
+### 4. Platform Vocabulary Download Is Best-Effort
+
+**Location:** `harvester/cde_harvester/platform_ioos_to_l06.py`
+
+IOOS → NERC L06 mapping is downloaded from the MMISW ontology server at harvest time. If the server is down, it silently falls back to a cached CSV. If the cache is also stale, datasets may be tagged with incorrect or missing platform codes.
+
+**Risk:** Silent data quality issues for platform filtering.
+
+---
+
+## Medium Risk
+
+### 5. Redis Cache Has No Invalidation Mechanism
+
+**Location:** `web-api/cache.js`, all route handlers
+
+Cache entries expire by TTL only. After a nightly DB load, the API continues serving stale data from Redis for up to 5 minutes. In production, a full reload takes ~10–30 minutes during which old data is shown.
+
+**Mitigation needed:** Cache flush triggered by db-loader on completion, or shorter TTL.
+
+---
+
+### 6. Download Size Limits Are Checked After Downloading
+
+**Location:** `downloader/erddap_downloader/download_erddap.py`
+
+The 1GB-per-dataset and 5GB-total limits are checked after the data has already been streamed from ERDDAP. For large datasets this means downloading gigabytes only to discard them.
+
+**Note:** `/downloadEstimate` exists to pre-check size, but it is called by the frontend as advisory only — a user can bypass it.
+
+**Mitigation needed:** Enforce estimate check server-side before inserting the download job, or implement streaming size check with early abort.
+
+---
+
+### 7. Harvester Thread Pool Has No Backpressure
+
+**Location:** `harvester/cde_harvester/__main__.py`
+
+All ERDDAP server URLs are submitted to the thread pool immediately. If the pool is processing a slow server, tasks for other servers queue up in memory. For very large server lists this could consume significant memory.
+
+**Mitigation needed:** Bounded queue with backpressure, or sequential per-server processing with async I/O.
+
+---
+
+### 8. CKAN Lookup Is Synchronous and Unbounded
+
+**Location:** `harvester/cde_harvester/utils.py`
+
+For each dataset, a synchronous HTTP request is made to CKAN. There is no connection pool, timeout, or circuit breaker. A slow CKAN response blocks the harvest thread for that dataset indefinitely.
+
+**Mitigation needed:** Set request timeout, cache CKAN responses, or batch-fetch organizations.
+
+---
+
+### 9. Hardcoded SQL in db-loader
+
+**Location:** `db-loader/cde_db_loader/db_loader.py`, `incremental_db_loader.py`
+
+Table names, schema names, and column lists are hardcoded as string literals. Changes to the database schema require coordinated updates in multiple Python files with no compile-time checking.
+
+**Mitigation needed:** Schema migration tool (e.g., Alembic), or at minimum extract table/column names to constants.
+
+---
+
+### 10. No Health Checks on Services
+
+**Location:** `docker-compose.yaml`, `docker-compose.production.yaml`
+
+The download scheduler and harvester have no liveness/readiness probes. A crashed scheduler is invisible until a user notices their download never arrived.
+
+**Mitigation needed:** Heartbeat table updated by scheduler; alerting on stale heartbeat.
+
+---
+
+## Low Risk
+
+### 11. Frontend Has No End-to-End Tests
+
+**Location:** `frontend/`
+
+No Playwright/Cypress tests cover the critical user path (draw polygon → filter → download). Changes to Map.js or Filter.jsx could silently break the UX.
+
+---
+
+### 12. Inconsistent Error Logging
+
+**Location:** All Python modules
+
+Some modules use `loguru`, some use the standard `logging` module, and some use bare `print()` statements. Log aggregation is inconsistent.
+
+---
+
+### 13. `cioos_erddap_servers.csv` Is Manually Maintained
+
+**Location:** `harvester/cioos_erddap_servers.csv`
+
+Adding a new ERDDAP server requires a manual git commit. No admin interface or automated discovery exists.
+
+---
+
+### 14. i18n Strings Are Partially Complete
+
+**Location:** `frontend/src/locales/`
+
+Some French translations are missing or fall back to English strings. No CI check enforces translation completeness.
+
+---
+
+### 15. `harvest_config.yaml` Is Not Validated on Load
+
+**Location:** `harvester/cde_harvester/__main__.py`
+
+The YAML config is loaded with `yaml.safe_load()` and accessed by key without schema validation. A typo in the config (e.g., `max_workers` instead of `max-workers`) silently uses a default or raises a confusing `KeyError`.
+
+**Mitigation needed:** Pydantic or `cerberus` schema validation on startup.

--- a/docs/tests.md
+++ b/docs/tests.md
@@ -1,0 +1,560 @@
+# Test Suite Documentation
+
+## Overview
+
+The test suite lives in `tests/` and covers the harvester ETL pipeline end-to-end: ERDDAP HTTP calls, dataset compliance checking, profile statistics extraction, CSV output, and database loading. All external I/O is mocked — no live ERDDAP, CKAN, or database connections are required.
+
+**133 tests, 0 failures.**
+
+```
+tests/
+├── pyproject.toml              # uv project; harvester + db-loader as editable installs
+├── conftest.py                 # shared fixtures, mock CSV data, ERDDAP response routing
+├── unit/                       # 110 tests across 9 modules
+│   ├── test_erddap_client.py
+│   ├── test_dataset.py
+│   ├── test_compliance_checker.py
+│   ├── test_profiles.py
+│   ├── test_utils.py
+│   ├── test_ckan.py
+│   ├── test_harvest_erddap.py
+│   ├── test_csv_generation.py
+│   └── test_db_loader.py
+└── integration/                # 23 tests
+    └── test_full_pipeline.py
+```
+
+---
+
+## Running the Tests
+
+```bash
+cd tests/
+uv sync                        # first time: install deps into .venv
+uv run pytest                  # run everything
+uv run pytest unit/            # unit tests only
+uv run pytest integration/     # integration test only
+uv run pytest -k "compliance"  # by keyword
+uv run pytest -v --tb=long     # verbose with full tracebacks
+```
+
+---
+
+## Architecture
+
+### Dependency Management
+
+The test project is a standalone uv project with its own `pyproject.toml`. Both `harvester` and `db-loader` are declared as `editable = true` sources, so changes to the source tree are immediately reflected without reinstalling:
+
+```toml
+[tool.uv.sources]
+harvester = { path = "../harvester", editable = true }
+db-loader = { path = "../db-loader", editable = true }
+```
+
+### Mocking Strategy
+
+| Layer | Mocking approach |
+|-------|-----------------|
+| ERDDAP HTTP | `patch("cde_harvester.ERDDAP.requests.Session")` + `MockResponse` fixture |
+| CKAN HTTP | `patch("cde_harvester.ckan.create_ckan_erddap_link.requests.get")` |
+| Dataset objects | `MagicMock` with all required attributes set explicitly |
+| SQLAlchemy engine | `MagicMock` + `engine.begin.return_value.__enter__.return_value = conn` |
+| SQL text capture | `patch("cde_db_loader.__main__.text", side_effect=lambda s: ...)` |
+| DataFrame writes | `patch("pandas.DataFrame.to_sql")` |
+| Sentry SDK | Module-level `_sentry_init_patcher.start()` in conftest — prevents `BadDsn` errors from sentry 2.x when `SENTRY_DSN` is unset |
+
+### conftest.py — Shared Infrastructure
+
+`tests/conftest.py` is the backbone of the test suite. It contains:
+
+**Fixture CSV strings** — static multi-line strings that reproduce exact ERDDAP response formats, including the units rows that `erddap_csv_to_df` skips:
+
+| Constant | Endpoint / Purpose |
+|----------|--------------------|
+| `ERDDAP_ALL_DATASETS_CSV` | `/tabledap/allDatasets.csv` — `skiprows=[1, 2]` |
+| `ERDDAP_INFO_CSV` | `/info/{id}/index.csv` — `skiprows=[]`, valid TimeSeries dataset |
+| `ERDDAP_INFO_NO_EOVS_CSV` | Info CSV with unsupported standard names only |
+| `ERDDAP_INFO_INGEST_FALSE_CSV` | Info CSV with `cde_ingest=False` global |
+| `ERDDAP_INFO_DEPTH_AND_ALTITUDE_CSV` | Info CSV with both `depth` and `altitude` variables |
+| `ERDDAP_PROFILE_IDS_CSV` | `?station_id,lat,lon&distinct()` — single station |
+| `ERDDAP_PROFILE_IDS_TWO_CSV` | Same query — two stations |
+| `ERDDAP_TIME_MINMAX_CSV` | `?orderByMinMax(...)` for time — 2 stations × 2 rows (max/min pairs) |
+| `ERDDAP_DEPTH_MINMAX_CSV` | `?orderByMinMax(...)` for depth |
+| `ERDDAP_COUNT_CSV` | `?orderByCount(...)` — record counts per station |
+| `CKAN_PACKAGE_SEARCH_RESPONSE` | CKAN `/action/package_search` page 1 JSON |
+| `CKAN_EMPTY_RESPONSE` | CKAN page 2 (stops pagination) |
+
+**URL router** — `_route_erddap_url(url)` decodes the request URL and dispatches to the right fixture CSV. This is used by `make_mock_session_get`, the `side_effect` function wired to `requests.Session.get` in tests that use the real `ERDDAP` class.
+
+**`build_variables_df()`** — reproduces the exact `df_variables` DataFrame that `Dataset.get_metadata()` builds from the info CSV, so unit tests for `CDEComplianceChecker` and `get_profiles` can receive a realistic object without making HTTP calls.
+
+**`build_mock_dataset()`** — constructs a `MagicMock` with all attributes that `CDEComplianceChecker` and `get_profiles` access: `df_variables`, `variables_list`, `globals`, `eovs`, `profile_variables`, `profile_variable_list`, `get_profile_ids()`, `get_max_min()`, `get_count()`, `get_df()`. It derives EOVs using the real `cde_eov_to_standard_name` mapping so the output is realistic.
+
+### Unit Test Pattern
+
+Each unit test file imports from `conftest` and the module under test. Tests are grouped into classes by scenario:
+
+```python
+class TestPassesAllChecks:
+    def test_valid_timeseries_dataset_passes(self):
+        checker = _checker()          # build from fixture CSV
+        assert checker.passes_all_checks() is True
+
+class TestRequiredVariables:
+    def test_missing_time_fails(self):
+        checker = _checker()
+        checker.dataset.variables_list.remove("time")
+        assert checker.check_required_variables() is False
+        assert checker.failure_reason_code == MISSING_REQUIRED_VARS
+```
+
+### Integration Test Pattern
+
+`test_full_pipeline.py` uses `scope="module"` fixtures that chain: each phase consumes the output of the previous phase.
+
+```
+harvest_result (module fixture)
+  ↓ mocked ERDDAP session + CKAN get
+  ↓ real harvest_erddap()
+  ↓ produces (profiles, datasets, variables, skipped) DataFrames
+  ↓
+written_csv_folder (module fixture, depends on harvest_result)
+  ↓ real harvester_main() — merges CKAN data, writes CSVs to tmp_path
+  ↓ produces datasets.csv, profiles.csv, skipped.csv
+  ↓
+db_load_calls (module fixture, depends on written_csv_folder)
+  ↓ real db_main() with mocked SQLAlchemy engine
+  ↓ captures SQL text strings passed to text()
+  ↓ returns list of SQL strings for assertion
+```
+
+---
+
+## Integration Test Data Flow
+
+The integration test exercises the complete pipeline described in `docs/data_flow.md`:
+
+```
+ERDDAP Servers (mocked)          CKAN (mocked)
+  │ allDatasets.csv                │ package_search JSON
+  │ info/{id}/index.csv            │ (1 page + empty terminator)
+  │ distinct() profile IDs         │
+  │ orderByMinMax() time/depth     │
+  │ orderByCount() records         │
+  └─────────────┬──────────────────┘
+                │
+      harvest_erddap()         ← real code, mocked I/O
+      CDEComplianceChecker     ← real code
+      get_profiles()           ← real code
+                │
+                ▼
+      (profiles_df, datasets_df, variables_df, skipped_df)
+      [tested by TestHarvestOutput — 6 assertions]
+                │
+                ▼
+      harvester_main()         ← real code
+        CKAN merge              (title, title_fr, organizations)
+        deduplication
+        CSV write (tmp_path)
+                │
+                ▼
+      datasets.csv  profiles.csv  skipped.csv  ckan.csv
+      [tested by TestCsvFilesWritten — 8 assertions]
+                │
+                ▼
+      db_main()               ← real code, mocked engine
+        pd.read_csv()          real parsing of written CSVs
+        ast.literal_eval()     real array column parsing
+        engine.begin() → conn  mocked context manager
+        conn.execute(text(...)) captured via text() patch
+                │
+                ▼
+      SQL call list
+      [tested by TestDbLoadPhase — 5 assertions]
+```
+
+---
+
+## All Existing Tests
+
+### `unit/test_erddap_client.py` — 14 tests
+
+#### `TestERDDAPInit`
+| Test | What it verifies |
+|------|-----------------|
+| `test_url_is_stored` | `ERDDAP.url` is set from the constructor argument |
+| `test_domain_extracted_from_url` | `ERDDAP.domain` extracts the netloc correctly |
+| `test_get_all_datasets_returns_dataframe` | `df_all_datasets` is a DataFrame on successful init |
+| `test_get_all_datasets_has_expected_columns` | `datasetID` and `cdm_data_type` columns present |
+| `test_get_all_datasets_skips_units_rows` | Units row (`"(String)"`) is not present in output |
+| `test_empty_response_gives_empty_dataframe` | All-units CSV produces an empty DataFrame |
+
+#### `TestErddapCsvToDf`
+| Test | What it verifies |
+|------|-----------------|
+| `test_200_response_returns_dataframe` | A 200 OK response is parsed into a DataFrame |
+| `test_404_returns_empty_dataframe` | HTTP 404 is treated as no-data, returns empty |
+| `test_500_no_matching_results_returns_empty` | ERDDAP "no matching results" 500 returns empty |
+| `test_500_other_error_raises` | Other 500 errors raise `HTTPError` |
+| `test_response_too_large_raises` | Responses exceeding 200 MB raise `RuntimeError` |
+
+#### `TestParseErddapDate`
+| Test | What it verifies |
+|------|-----------------|
+| `test_iso8601_string` | ISO 8601 strings are parsed correctly |
+| `test_large_epoch_is_not_timestamp` | Scientific-notation epochs (`"1.5E9"`) are parsed as timestamps |
+| `test_invalid_string_returns_nat` | Unparseable strings return `NaT` |
+
+---
+
+### `unit/test_dataset.py` — 15 tests
+
+#### `TestDatasetMetadataParsing`
+| Test | What it verifies |
+|------|-----------------|
+| `test_id_stored` | `dataset.id` holds the dataset ID |
+| `test_erddap_url_stored` | `dataset.erddap_url` holds the server URL |
+| `test_cdm_data_type_parsed` | `cdm_data_type` is read from `NC_GLOBAL` attributes |
+| `test_globals_dict_populated` | `globals` dict contains title and institution |
+| `test_variables_list_contains_expected_vars` | All variables in the info CSV are in `variables_list` |
+| `test_df_variables_index_is_variable_names` | `df_variables` is indexed by variable name |
+| `test_standard_name_attribute_parsed` | `standard_name` attribute is present on the `temperature` variable |
+| `test_cf_role_attribute_parsed` | `cf_role` attribute is present on the `station_id` variable |
+| `test_organization_extracted_from_institution` | `institution` global populates `organizations` list |
+| `test_platform_defaults_to_unknown_when_no_platform_global` | Missing platform globals → `"unknown"` |
+
+#### `TestDatasetEOVMapping`
+| Test | What it verifies |
+|------|-----------------|
+| `test_eovs_populated_when_supported_var_present` | `sea_water_temperature` variable produces a non-empty `eovs` list |
+| `test_eovs_empty_when_no_supported_standard_names` | Dataset with only unsupported standard names → empty `eovs` |
+| `test_first_eov_column_set` | `first_eov_column` is set to the variable name that triggered the first EOV match |
+
+#### `TestDatasetGetDf`
+| Test | What it verifies |
+|------|-----------------|
+| `test_get_df_returns_dataframe` | `get_df()` returns a DataFrame |
+| `test_get_df_contains_required_columns` | Output has all columns needed for `datasets.csv` |
+
+---
+
+### `unit/test_compliance_checker.py` — 15 tests
+
+#### `TestPassesAllChecks`
+| Test | What it verifies |
+|------|-----------------|
+| `test_valid_timeseries_dataset_passes` | A complete, valid dataset passes all checks |
+| `test_failure_reason_code_empty_on_pass` | `failure_reason_code` is `""` when passing |
+
+#### `TestRequiredVariables`
+| Test | What it verifies |
+|------|-----------------|
+| `test_missing_time_fails` | Missing `time` → `MISSING_REQUIRED_VARS` |
+| `test_missing_latitude_fails` | Missing `latitude` → `MISSING_REQUIRED_VARS` |
+| `test_missing_longitude_fails` | Missing `longitude` → `MISSING_REQUIRED_VARS` |
+| `test_all_required_present_passes` | All three LLAT vars present → passes |
+
+#### `TestSupportedCFName`
+| Test | What it verifies |
+|------|-----------------|
+| `test_dataset_with_sea_water_temperature_passes` | Known EOV standard name → passes |
+| `test_dataset_with_no_supported_standard_names_fails` | No CDE-mapped standard names → `NO_SUPPORTED_VARIABLES` |
+
+#### `TestIngestFlag`
+| Test | What it verifies |
+|------|-----------------|
+| `test_no_cde_ingest_flag_passes` | Absent `cde_ingest` global → passes |
+| `test_cde_ingest_false_fails` | `cde_ingest=False` → `INGEST_FLAG_FALSE` |
+| `test_cde_ingest_true_passes` | `cde_ingest=True` → passes |
+
+#### `TestDepthAndAltitude`
+| Test | What it verifies |
+|------|-----------------|
+| `test_only_depth_passes` | Depth without altitude → passes |
+| `test_depth_and_altitude_together_fails` | Both depth and altitude → `DEPTH_AND_ALTITUDE` |
+| `test_only_altitude_passes` | Altitude without depth → passes |
+
+---
+
+### `unit/test_profiles.py` — 13 tests
+
+#### `TestGetProfilesHappyPath`
+| Test | What it verifies |
+|------|-----------------|
+| `test_returns_dataframe` | `get_profiles()` returns a DataFrame |
+| `test_result_is_not_empty` | A valid dataset produces at least one profile row |
+| `test_required_columns_present` | All output columns required by the DB schema are present |
+| `test_dataset_id_matches` | `dataset_id` column is populated correctly |
+| `test_erddap_url_matches` | `erddap_url` column is populated correctly |
+| `test_latitude_preserved` | Latitude from profile IDs survives to the output |
+| `test_longitude_preserved` | Longitude from profile IDs survives to the output |
+| `test_time_min_is_datetime` | `time_min` column is a datetime dtype after `parse_erddap_dates` |
+| `test_depth_defaults_to_zero_when_no_depth_var` | Datasets without a `depth` variable get `depth_min=0`, `depth_max=0` |
+| `test_records_per_day_is_positive` | `records_per_day` is calculated and positive |
+
+#### `TestGetProfilesEmptyAndEdgeCases`
+| Test | What it verifies |
+|------|-----------------|
+| `test_empty_profile_ids_returns_empty` | If `get_profile_ids()` returns empty, `get_profiles()` returns empty |
+| `test_bad_latitude_profile_filtered_out` | Profile with latitude > 90 is removed by the bad-geometry filter |
+| `test_profile_id_column_added_when_missing` | TimeSeries datasets (no `profile_id` variable) get `profile_id=""` |
+
+---
+
+### `unit/test_utils.py` — 11 tests
+
+#### `TestIntersection`
+| Test | What it verifies |
+|------|-----------------|
+| `test_returns_common_elements` | Shared elements from two lists are returned |
+| `test_returns_empty_when_no_overlap` | No overlap → empty list |
+| `test_excludes_empty_strings` | Empty string `""` is never included in the result |
+| `test_order_follows_first_list` | Result order matches the first argument |
+| `test_empty_lists_return_empty` | Two empty lists → empty result |
+
+#### `TestCdeEovMappings`
+| Test | What it verifies |
+|------|-----------------|
+| `test_mapping_is_non_empty` | `cde_eov_to_standard_name` has at least one entry |
+| `test_most_eovs_map_to_at_least_one_standard_name` | Majority of EOVs have CF standard names (some, e.g. `fishAbundanceAndDistribution`, intentionally have none) |
+| `test_sea_water_temperature_is_supported` | `sea_water_temperature` is in `supported_standard_names` |
+| `test_df_has_expected_columns` | `df_cde_eov_to_standard_name` has `eov` and `standard_name` columns |
+| `test_df_rows_match_mapping` | Every row in the DataFrame is consistent with the dict mapping |
+| `test_goos_and_cde_layers_both_collapsed` | `get_cde_eov_to_standard_name()` returns a flat dict keyed by CDE EOV names |
+
+---
+
+### `unit/test_ckan.py` — 11 tests
+
+#### `TestSplitErddapUrl`
+| Test | What it verifies |
+|------|-----------------|
+| `test_standard_tabledap_url` | Splits a standard ERDDAP tabledap URL into host and dataset ID |
+| `test_url_with_language_prefix` | Handles URLs with language prefix (`/erddap/fr/tabledap/`) |
+| `test_invalid_url_raises_value_error` | Non-ERDDAP URL raises `ValueError` with a clear message |
+
+#### `TestUnescapeAscii`
+| Test | What it verifies |
+|------|-----------------|
+| `test_plain_string_unchanged` | Plain ASCII strings pass through unchanged |
+| `test_non_ascii_fallback_returns_input` | Non-decodable input is returned as-is |
+| `test_list_unescaping` | `unescape_ascii_list` applies the transform to every element |
+
+#### `TestGetCkanRecords`
+| Test | What it verifies |
+|------|-----------------|
+| `test_returns_dataframe` | `get_ckan_records()` returns a DataFrame |
+| `test_dataframe_has_expected_columns` | All columns required by the CKAN join in `__main__.py` are present |
+| `test_dataset_id_matched` | A known dataset ID appears in the output |
+| `test_title_extracted` | English and French titles are extracted from `title_translated` |
+| `test_no_matching_dataset_returns_empty` | Filtering for a non-existent dataset ID returns an empty DataFrame |
+
+---
+
+### `unit/test_harvest_erddap.py` — 7 tests
+
+#### `TestHarvestErddapHappyPath`
+| Test | What it verifies |
+|------|-----------------|
+| `test_result_appended` | `harvest_erddap()` appends one entry to the `result` list |
+| `test_result_contains_four_dataframes` | Each result entry is `(profiles, datasets, variables, skipped)` |
+| `test_compliant_dataset_appears_in_datasets` | A compliant dataset ID appears in the datasets DataFrame |
+| `test_dataset_id_filter_respected` | `limit_dataset_ids` excludes datasets not in the list |
+
+#### `TestHarvestErddapSkipping`
+| Test | What it verifies |
+|------|-----------------|
+| `test_unsupported_cdm_type_skipped` | `Point`-type datasets never reach `get_dataset`; appear in skipped with `CDM_DATA_TYPE_UNSUPPORTED` |
+| `test_non_compliant_dataset_added_to_skipped` | A dataset that fails compliance checks is in `skipped`, not `datasets` |
+| `test_http_error_adds_to_skipped` | `HTTPError` from `get_dataset` adds the dataset to skipped with `HTTP_ERROR` (also tests the bug fix: `dataset_logger` initialised to module logger before the try block) |
+
+---
+
+### `unit/test_csv_generation.py` — 11 tests
+
+#### `TestDatasetsCsvStructure`
+| Test | What it verifies |
+|------|-----------------|
+| `test_all_required_columns_present` | `datasets.csv` has all columns the DB loader expects |
+| `test_dataset_id_is_non_empty` | No blank dataset IDs |
+| `test_eovs_is_list_after_roundtrip` | `eovs` column round-trips through CSV as a Python list via `ast.literal_eval` |
+| `test_organizations_is_list_after_roundtrip` | Same for `organizations` |
+| `test_profile_variables_is_list_after_roundtrip` | Same for `profile_variables` |
+| `test_no_duplicate_dataset_ids_after_write` | `drop_duplicates(["erddap_url", "dataset_id"])` produces no duplicates |
+
+#### `TestProfilesCsvStructure`
+| Test | What it verifies |
+|------|-----------------|
+| `test_all_required_columns_present` | `profiles.csv` has all DB-required columns |
+| `test_latitude_within_bounds` | All latitudes are in (−90, 90) |
+| `test_longitude_within_bounds` | All longitudes are in (−180, 180) |
+| `test_depth_min_le_depth_max` | `depth_min ≤ depth_max` for all rows |
+| `test_time_min_before_time_max` | `time_min < time_max` for all rows |
+| `test_n_records_positive` | Record count is > 0 |
+| `test_roundtrip_preserves_row_count` | Writing and re-reading `profiles.csv` preserves the row count |
+
+#### `TestSkippedCsvStructure`
+| Test | What it verifies |
+|------|-----------------|
+| `test_all_required_columns_present` | `skipped.csv` has `erddap_url`, `dataset_id`, `reason_code` |
+| `test_reason_code_is_non_empty` | Every skipped row has a non-blank reason code |
+| `test_roundtrip_preserves_data` | Reason codes survive a CSV write/read cycle unchanged |
+
+---
+
+### `unit/test_db_loader.py` — 13 tests
+
+#### `TestPrepareProfilesDataframe`
+| Test | What it verifies |
+|------|-----------------|
+| `test_removes_altitude_columns` | `altitude_min`/`altitude_max` are dropped |
+| `test_drops_rows_where_time_min_is_null` | Rows with null `time_min` are excluded |
+| `test_replaces_empty_strings_with_nan` | Empty strings are replaced with `NaN` before DB insert |
+| `test_valid_rows_preserved` | Rows with valid data survive the clean step |
+
+#### `TestEnsureOrganizationPks`
+| Test | What it verifies |
+|------|-----------------|
+| `test_missing_column_gets_empty_arrays` | Missing `organization_pks` column → column of empty lists |
+| `test_null_values_replaced_with_empty_lists` | Null values in the column → empty lists |
+
+#### `TestDbLoaderMainFullReload`
+| Test | What it verifies |
+|------|-----------------|
+| `test_drop_constraints_called` | `SELECT drop_constraints()` is executed before data load |
+| `test_remove_all_data_called` | `SELECT remove_all_data()` is executed to clear tables |
+| `test_profile_process_called` | `SELECT profile_process()` is executed to link profiles |
+| `test_set_constraints_called` | `SELECT set_constraints()` is executed to re-add FK constraints |
+
+#### `TestDbLoaderMainIncremental`
+| Test | What it verifies |
+|------|-----------------|
+| `test_create_temp_tables_called` | `SELECT create_temp_tables()` is called to prepare staging |
+| `test_process_incremental_update_called` | `SELECT process_incremental_update()` is called for UPSERT |
+| `test_drop_constraints_not_called_in_incremental` | Full-reload-only SQL (`drop_constraints`, `remove_all_data`) are NOT called in incremental mode |
+
+---
+
+### `integration/test_full_pipeline.py` — 23 tests
+
+#### `TestHarvestOutput` — validates the raw harvest DataFrames
+| Test | What it verifies |
+|------|-----------------|
+| `test_compliant_dataset_is_harvested` | The compliant test dataset ID appears in the datasets DataFrame |
+| `test_at_least_one_profile_extracted` | At least one row is produced in the profiles DataFrame |
+| `test_profiles_have_required_columns` | All 9 required profile columns are present |
+| `test_dataset_has_eovs` | The harvested dataset has at least one EOV mapped |
+| `test_unsupported_dataset_is_skipped` | `test_unsupported_001` (Point type from the allDatasets fixture) does not appear in datasets |
+| `test_variables_dataframe_populated` | The variables DataFrame has rows and a `standard_name` column |
+
+#### `TestCsvFilesWritten` — validates the CSV output phase
+| Test | What it verifies |
+|------|-----------------|
+| `test_datasets_csv_exists` | `datasets.csv` is created in the output folder |
+| `test_profiles_csv_exists` | `profiles.csv` is created |
+| `test_skipped_csv_exists` | `skipped.csv` is created |
+| `test_datasets_csv_readable` | `datasets.csv` can be parsed by `pd.read_csv` and is non-empty |
+| `test_profiles_csv_readable` | Same for `profiles.csv` |
+| `test_datasets_csv_array_columns_parse_correctly` | `eovs`, `organizations`, `profile_variables` survive CSV roundtrip as Python lists |
+| `test_ckan_title_merged_into_datasets` | CKAN English title is merged into the `title` column |
+| `test_french_title_present` | CKAN French title is present in `title_fr` |
+
+#### `TestDbLoadPhase` — validates the database loading phase
+| Test | What it verifies |
+|------|-----------------|
+| `test_drop_constraints_called` | Full-reload begins by dropping FK constraints |
+| `test_remove_all_data_called` | All existing data is cleared before reload |
+| `test_profile_process_called` | Profile linkage SQL function is invoked |
+| `test_create_hexes_called` | Spatial hex aggregation SQL function is invoked |
+| `test_set_constraints_called` | FK constraints are re-applied at the end |
+
+---
+
+## Recommendations for Adding More Tests
+
+### 1. Test the multi-profile (orderByMinMax) code path
+
+All current `get_profiles` unit tests use the `actual_range` shortcut (single-profile dataset). Add tests that exercise the `get_max_min` join path with two or more profiles, using `ERDDAP_PROFILE_IDS_TWO_CSV` and `ERDDAP_TIME_MINMAX_CSV` / `ERDDAP_DEPTH_MINMAX_CSV` from conftest.
+
+```python
+@pytest.fixture
+def two_station_dataset():
+    ds = build_mock_dataset()
+    ds.profile_ids = pd.read_csv(StringIO(ERDDAP_PROFILE_IDS_TWO_CSV), skiprows=[1])
+    ds.get_profile_ids.return_value = ds.profile_ids.copy()
+    # Remove actual_range so get_max_min path is forced
+    ds.df_variables.loc["time", "actual_range"] = ""
+    ds.df_variables.loc["depth", "actual_range"] = ""
+    ds.get_max_min.side_effect = _two_station_max_min  # return 2-row DataFrames
+    return ds
+```
+
+### 2. Test TimeSeriesProfile CDM type
+
+The current fixtures only cover `TimeSeries`. Add an info CSV fixture with `cdm_data_type=TimeSeriesProfile` and a `profile_id` cf_role variable, then verify the "too many profiles per timeseries" grouping logic inside `get_profiles`.
+
+### 3. Test the 180° meridian crossing in the downloader
+
+`erddap_downloader/download_erddap.py` has special logic to split queries when a polygon crosses the antimeridian. Add unit tests for the query-splitting function directly, using a polygon WKT that straddles ±180°.
+
+### 4. Test incremental DB load data integrity
+
+The current incremental DB loader tests only verify SQL calls. Add tests that:
+- Write a first harvest CSV, load it, then write a second CSV with one changed row and one deleted row
+- Assert the `process_incremental_update` would UPSERT the changed row and delete the missing one
+
+Since this requires real SQL execution, use SQLite in-memory as the engine (SQLAlchemy 1.x supports it) rather than a MagicMock.
+
+### 5. Add a CF version check test
+
+`utils.py` has this comment:
+```python
+# TODO: add pytest to verify check_cf_version detects when a newer CF standard names version is available
+```
+Test `check_cf_version()` by mocking `get_cf_version_from_xml` to return a version string different from the local one and assert that a warning is logged.
+
+```python
+def test_check_cf_version_warns_on_update(mocker, caplog):
+    mocker.patch(
+        "cde_harvester.utils.get_cf_version_from_xml",
+        return_value="999"
+    )
+    with caplog.at_level(logging.WARNING):
+        check_cf_version()
+    assert "CF standard names update available" in caplog.text
+```
+
+### 6. Parametrize compliance checker tests
+
+The four compliance rules are currently tested with separate fixture CSVs. Refactor to `@pytest.mark.parametrize` so every rule variation is explicit and easy to extend:
+
+```python
+@pytest.mark.parametrize("info_csv, expected_code", [
+    (ERDDAP_INFO_NO_EOVS_CSV,            NO_SUPPORTED_VARIABLES),
+    (ERDDAP_INFO_INGEST_FALSE_CSV,       INGEST_FLAG_FALSE),
+    (ERDDAP_INFO_DEPTH_AND_ALTITUDE_CSV, DEPTH_AND_ALTITUDE),
+])
+def test_non_compliant_dataset_rejected(info_csv, expected_code):
+    checker = CDEComplianceChecker(build_mock_dataset(info_csv))
+    assert checker.passes_all_checks() is False
+    assert checker.failure_reason_code == expected_code
+```
+
+### 7. Test download scheduler job lifecycle
+
+`download_scheduler.py` has no tests. The core logic (poll → lock → download → update status → email) can be tested by mocking the psycopg2 connection and `downloader_wrapper.run_download_query`. Priority: test the `FOR UPDATE SKIP LOCKED` path and the status transitions (`open` → `in_progress` → `completed`/`failed`).
+
+### 8. Add API route tests
+
+The web API (`web-api/`) has no test coverage. Add a `tests/api/` directory using `supertest` (Node.js) or a mock Express app, and test the `/datasets`, `/tiles`, and `/download` endpoints with a stubbed Knex connection.
+
+---
+
+## Bug Fixed During Test Development
+
+The test suite exposed a latent bug in `harvester/cde_harvester/harvest_erddap.py`:
+
+`dataset_logger` was used in the `except HTTPError` handler before it was guaranteed to be assigned (it was only set after a successful `erddap.get_dataset()` call). When `get_dataset()` raised an `HTTPError`, Python raised `UnboundLocalError`.
+
+**Fix applied:** `dataset_logger = logger` (module-level fallback) is now assigned before the try block. If `get_dataset()` succeeds, `dataset_logger` is then overwritten with `dataset.logger`.

--- a/harvester/cde_harvester/harvest_erddap.py
+++ b/harvester/cde_harvester/harvest_erddap.py
@@ -127,6 +127,7 @@ def harvest_erddap(erddap_url, result, limit_dataset_ids=None, cache_requests=Fa
             continue
         try:
             logger.info(f"Querying dataset: {dataset_id} {i+1}/{len(df_all_datasets)}")
+            dataset_logger = logger  # fallback until dataset is loaded
             dataset = erddap.get_dataset(dataset_id)
             dataset_logger = dataset.logger
             compliance_checker = CDEComplianceChecker(dataset)

--- a/harvester/harvest_validator/__init__.py
+++ b/harvester/harvest_validator/__init__.py
@@ -1,0 +1,19 @@
+"""
+harvest_validator — run-time validation tool for the CIOOS harvester pipeline.
+
+Instruments a live harvest run, captures every log message, HTTP call, and
+data-transformation event, then produces a per-run report that surfaces:
+  • Failures and error conditions at each pipeline stage
+  • Data-quality issues in the produced DataFrames
+  • Unhandled exception patterns and known code-level bugs
+  • Performance anomalies (slow servers, oversized responses)
+  • Skip-analysis breakdown by reason code
+  • HTTP API call statistics
+
+Usage:
+    python -m harvest_validator -f harvest_config.yaml [--output-dir ./reports]
+"""
+
+from .runner import HarvestRunner, HarvestArtifacts  # noqa: F401
+from .analyzers import analyze, HarvestAnalysis       # noqa: F401
+from .reporter import ReportWriter                    # noqa: F401

--- a/harvester/harvest_validator/__main__.py
+++ b/harvester/harvest_validator/__main__.py
@@ -1,0 +1,210 @@
+"""
+harvest_validator — CLI entry point.
+
+Usage:
+    python -m harvest_validator -f harvest_config.yaml
+    python -m harvest_validator -f harvest_config.yaml --output-dir ./reports
+    python -m harvest_validator -f harvest_config.yaml --output-dir ./reports --format json
+
+Options:
+    -f / --file        Path to harvest_config.yaml (required)
+    --output-dir       Directory to write reports into (default: ./validation_reports)
+    --format           Output format: 'all' (default), 'md', or 'json'
+    --run-id           Override the auto-generated run ID (YYYYMMDD_HHMMSS)
+
+The tool:
+  1. Reads the harvest config
+  2. Runs the full harvest_erddap() pipeline with instrumentation active
+  3. Analyzes collected artifacts for failures, data quality issues,
+     unhandled error conditions, and performance anomalies
+  4. Writes a per-run report to <output-dir>/<run-id>/
+
+Exit codes:
+    0  — harvest completed; CRITICAL or HIGH findings were NOT detected
+    1  — harvest completed; at least one CRITICAL or HIGH finding detected
+    2  — tool itself failed (bad config, import error, etc.)
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+from datetime import datetime
+from pathlib import Path
+
+import yaml
+
+from .runner import HarvestRunner
+from .analyzers import analyze, CRITICAL, HIGH
+from .reporter import ReportWriter
+
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)-8s %(name)s : %(message)s",
+    datefmt="%H:%M:%S",
+)
+logger = logging.getLogger("harvest_validator")
+
+
+# ─── CLI ──────────────────────────────────────────────────────────────────────
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="python -m harvest_validator",
+        description="Run and validate a CIOOS harvest, producing a per-run report.",
+    )
+    p.add_argument(
+        "-f", "--file",
+        required=True,
+        metavar="CONFIG",
+        help="Path to harvest_config.yaml",
+    )
+    p.add_argument(
+        "--output-dir",
+        default="./validation_reports",
+        metavar="DIR",
+        help="Base directory for report output (default: ./validation_reports)",
+    )
+    p.add_argument(
+        "--run-id",
+        default=None,
+        metavar="ID",
+        help="Override auto-generated run ID (default: YYYYMMDD_HHMMSS)",
+    )
+    p.add_argument(
+        "--format",
+        choices=["all", "md", "json"],
+        default="all",
+        help="Report format: 'all' writes report.md + report.json + events.jsonl (default)",
+    )
+    return p
+
+
+# ─── Entry point ──────────────────────────────────────────────────────────────
+
+def main(argv=None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    # ── Load config ───────────────────────────────────────────────────────────
+    config_path = Path(args.file)
+    if not config_path.exists():
+        logger.error("Config file not found: %s", config_path)
+        return 2
+
+    try:
+        with config_path.open() as fh:
+            config: dict = yaml.safe_load(fh) or {}
+    except Exception as exc:
+        logger.error("Failed to parse config: %s", exc)
+        return 2
+
+    if not config.get("erddap_urls"):
+        logger.error("Config must contain at least one erddap_urls entry.")
+        return 2
+
+    # ── Prepare run ───────────────────────────────────────────────────────────
+    run_id = args.run_id or datetime.now().strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_dir) / run_id
+
+    logger.info("=" * 60)
+    logger.info("harvest_validator  run_id=%s", run_id)
+    logger.info("Config:     %s", config_path)
+    logger.info("Output:     %s", output_dir)
+    logger.info("Servers:    %d", len(config.get("erddap_urls", [])))
+    logger.info("=" * 60)
+
+    # ── Run harvest with instrumentation ──────────────────────────────────────
+    logger.info("Starting instrumented harvest run...")
+    runner = HarvestRunner(config, run_id)
+    artifacts = runner.run()
+
+    logger.info(
+        "Harvest complete in %s — %d dataset(s), %d profile(s), %d skipped",
+        artifacts.duration_human,
+        len(artifacts.datasets),
+        len(artifacts.profiles),
+        len(artifacts.skipped),
+    )
+
+    if artifacts.fatal_error:
+        logger.error("FATAL ERROR during harvest:\n%s", artifacts.fatal_error)
+
+    # ── Analyze ───────────────────────────────────────────────────────────────
+    logger.info("Analyzing artifacts...")
+    analysis = analyze(artifacts)
+
+    critical_count = sum(1 for f in analysis.findings if f.severity == CRITICAL)
+    high_count = sum(1 for f in analysis.findings if f.severity == HIGH)
+    total_findings = len(analysis.findings)
+
+    logger.info(
+        "Analysis complete — %d finding(s): %d CRITICAL, %d HIGH, %d other",
+        total_findings,
+        critical_count,
+        high_count,
+        total_findings - critical_count - high_count,
+    )
+
+    # ── Write report ──────────────────────────────────────────────────────────
+    logger.info("Writing and verifying report to %s ...", output_dir)
+    writer = ReportWriter(output_dir)
+    try:
+        report_dir = writer.write(analysis, artifacts.log_capture)
+    except ValueError as exc:
+        logger.error("REPORT VERIFICATION FAILED: %s", exc)
+        logger.error("The generated report is structurally invalid. Check the output directory.")
+        return 2
+
+    logger.info("Report verified and written:")
+    logger.info("  %s/report.md     — human-readable summary", report_dir)
+    logger.info("  %s/report.json   — machine-readable data", report_dir)
+    logger.info("  %s/events.jsonl  — full log event stream", report_dir)
+
+    # ── Print finding summary to stdout ───────────────────────────────────────
+    _print_summary(analysis)
+
+    # ── Exit code ─────────────────────────────────────────────────────────────
+    if critical_count > 0 or high_count > 0:
+        logger.warning(
+            "Returning exit code 1: %d CRITICAL and %d HIGH finding(s) detected.",
+            critical_count, high_count,
+        )
+        return 1
+    return 0
+
+
+def _print_summary(analysis) -> None:
+    """Print a brief finding summary to stdout after the run."""
+    print()
+    print("─" * 60)
+    print(f"  HARVEST VALIDATION SUMMARY  —  {analysis.run_id}")
+    print("─" * 60)
+    ds = analysis.data_summary
+    print(f"  Datasets harvested : {ds.get('datasets_harvested', 0)}")
+    print(f"  Datasets skipped   : {ds.get('datasets_skipped', 0)}")
+    print(f"  Profiles extracted : {ds.get('profiles_extracted', 0):,}")
+    print(f"  Duration           : {analysis.duration_human}")
+    print()
+
+    from .analyzers import CRITICAL, HIGH, MEDIUM, LOW, INFO
+    for sev in (CRITICAL, HIGH, MEDIUM, LOW, INFO):
+        bucket = [f for f in analysis.findings if f.severity == sev]
+        if bucket:
+            print(f"  [{sev:8s}] {len(bucket)} finding(s):")
+            for f in bucket:
+                print(f"    • [{f.category}] {f.title}")
+    if not analysis.findings:
+        print("  No issues detected.")
+
+    print("─" * 60)
+    print()
+
+
+# ─── Run ──────────────────────────────────────────────────────────────────────
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/harvester/harvest_validator/analyzers.py
+++ b/harvester/harvest_validator/analyzers.py
@@ -1,0 +1,653 @@
+"""
+HarvestAnalyzer — inspects HarvestArtifacts and produces a structured list of
+findings across six categories:
+
+  1. Fatal / server-level failures
+  2. HTTP errors and connectivity problems
+  3. Data integrity issues in output DataFrames
+  4. Known unhandled error patterns in log messages
+  5. Performance anomalies (slow servers, oversized responses)
+  6. Output completeness checks
+
+Each finding has a severity (CRITICAL → INFO), category, human-readable title
+and detail, and an optional list of affected dataset/server IDs.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+import pandas as pd
+
+from cde_harvester.harvest_errors import (
+    CDM_DATA_TYPE_UNSUPPORTED,
+    DEPTH_AND_ALTITUDE,
+    HTTP_ERROR,
+    INGEST_FLAG_FALSE,
+    MISSING_REQUIRED_VARS,
+    NO_SUPPORTED_VARIABLES,
+    UNKNOWN_ERROR,
+)
+
+
+# ─── Severity constants ────────────────────────────────────────────────────────
+
+CRITICAL = "CRITICAL"
+HIGH     = "HIGH"
+MEDIUM   = "MEDIUM"
+LOW      = "LOW"
+INFO     = "INFO"
+
+_SEVERITY_RANK = {CRITICAL: 0, HIGH: 1, MEDIUM: 2, LOW: 3, INFO: 4}
+
+# ─── Data classes ─────────────────────────────────────────────────────────────
+
+@dataclass
+class Finding:
+    severity: str
+    category: str
+    title: str
+    detail: str
+    affected: list[str] = field(default_factory=list)
+    count: int = 0
+
+
+@dataclass
+class SkipBreakdown:
+    reason_code: str
+    count: int
+    pct: float
+    examples: list[str]
+    description: str
+
+
+@dataclass
+class HarvestAnalysis:
+    """Complete analysis result — passed to ReportWriter."""
+    run_id: str
+    start_time: str
+    end_time: str
+    duration_s: float
+    duration_human: str
+    config_summary: dict
+    findings: list[Finding]
+    skip_breakdown: list[SkipBreakdown]
+    http_summary: dict
+    log_summary: dict
+    data_summary: dict
+    per_server_summary: dict
+    # Raw error log lines (ERROR + CRITICAL) included verbatim in the report
+    error_log_lines: list[str]
+
+
+# ─── Skip reason descriptions ──────────────────────────────────────────────────
+
+_SKIP_DESCRIPTIONS = {
+    CDM_DATA_TYPE_UNSUPPORTED: (
+        "CDM type is not TimeSeries/Profile/TimeSeriesProfile (expected; these datasets "
+        "are never applicable to CDE)"
+    ),
+    HTTP_ERROR:               "HTTP error fetching dataset metadata from ERDDAP",
+    MISSING_REQUIRED_VARS:    "Missing at least one LLAT variable (time, latitude, longitude)",
+    NO_SUPPORTED_VARIABLES:   "No CF standard names map to a CDE Essential Ocean Variable",
+    INGEST_FLAG_FALSE:        "ERDDAP admin set cde_ingest=False on this dataset",
+    DEPTH_AND_ALTITUDE:       "Dataset has both depth and altitude variables (ambiguous vertical axis)",
+    UNKNOWN_ERROR:            "An unhandled exception occurred during dataset processing",
+}
+
+
+# ─── Entry point ──────────────────────────────────────────────────────────────
+
+def analyze(artifacts) -> HarvestAnalysis:
+    """Analyze HarvestArtifacts and return a complete HarvestAnalysis."""
+    findings: list[Finding] = []
+
+    findings += _check_fatal_error(artifacts)
+    findings += _check_server_reachability(artifacts)
+    findings += _check_unknown_errors(artifacts)
+    findings += _check_http_errors(artifacts)
+    findings += _check_data_integrity(artifacts)
+    findings += _check_unhandled_patterns(artifacts)
+    findings += _check_performance(artifacts)
+    findings += _check_output_completeness(artifacts)
+
+    findings.sort(key=lambda f: _SEVERITY_RANK.get(f.severity, 99))
+
+    return HarvestAnalysis(
+        run_id=artifacts.run_id,
+        start_time=artifacts.start_time.isoformat(),
+        end_time=artifacts.end_time.isoformat(),
+        duration_s=artifacts.duration_s,
+        duration_human=artifacts.duration_human,
+        config_summary=_config_summary(artifacts.config),
+        findings=findings,
+        skip_breakdown=_skip_breakdown(artifacts.skipped),
+        http_summary=_http_summary(artifacts.http_tracker),
+        log_summary=_log_summary(artifacts.log_capture),
+        data_summary=_data_summary(artifacts),
+        per_server_summary=_per_server_summary(artifacts),
+        error_log_lines=_error_log_lines(artifacts.log_capture),
+    )
+
+
+# ─── Individual checks ────────────────────────────────────────────────────────
+
+def _check_fatal_error(a) -> list[Finding]:
+    if not a.fatal_error:
+        return []
+    return [Finding(
+        severity=CRITICAL,
+        category="Fatal Error",
+        title="Harvest terminated with an unhandled top-level exception",
+        detail=a.fatal_error,
+        count=1,
+    )]
+
+
+def _check_server_reachability(a) -> list[Finding]:
+    """Flag any server where every single HTTP call failed."""
+    findings = []
+    by_server: dict[str, list] = {}
+    for call in a.http_tracker.calls:
+        by_server.setdefault(call.server, []).append(call)
+
+    for server, calls in by_server.items():
+        if calls and all(not c.ok for c in calls):
+            first_err = calls[0].error or f"HTTP {calls[0].status}"
+            findings.append(Finding(
+                severity=CRITICAL,
+                category="Server Unreachable",
+                title=f"All {len(calls)} request(s) to {server} failed",
+                detail=f"First error: {first_err}. Server may be down or URL incorrect.",
+                affected=[server],
+                count=len(calls),
+            ))
+    return findings
+
+
+def _check_unknown_errors(a) -> list[Finding]:
+    """Datasets that raised unexpected exceptions (UNKNOWN_ERROR reason code)."""
+    if a.skipped.empty:
+        return []
+    unknown = a.skipped[a.skipped["reason_code"] == UNKNOWN_ERROR]
+    if unknown.empty:
+        return []
+
+    # Count log entries that include stack traces
+    traces = [r for r in a.log_capture.errors if r.exc_info]
+    examples = unknown["dataset_id"].head(5).tolist()
+
+    return [Finding(
+        severity=HIGH,
+        category="Unhandled Exception",
+        title=f"{len(unknown)} dataset(s) failed with an unexpected exception",
+        detail=(
+            f"These datasets raised exceptions not caught by the expected error handlers. "
+            f"Stack traces captured in log: {len(traces)}. "
+            f"See 'Error Log Entries' section for details."
+        ),
+        affected=examples,
+        count=len(unknown),
+    )]
+
+
+def _check_http_errors(a) -> list[Finding]:
+    """Group HTTP failures by status code and emit one finding per group."""
+    findings = []
+    by_status: dict[str, list] = {}
+    for call in a.http_tracker.calls:
+        if not call.ok:
+            key = str(call.status) if call.status else "connection_error"
+            by_status.setdefault(key, []).append(call)
+
+    for status, calls in sorted(by_status.items()):
+        severity = HIGH if (status.startswith("5") or status == "connection_error") else MEDIUM
+        sample = [c.url[:100] for c in calls[:3]]
+        findings.append(Finding(
+            severity=severity,
+            category="HTTP Error",
+            title=f"{len(calls)} HTTP request(s) returned status {status}",
+            detail="First affected URLs:\n  " + "\n  ".join(sample),
+            affected=[c.url for c in calls],
+            count=len(calls),
+        ))
+    return findings
+
+
+def _check_data_integrity(a) -> list[Finding]:
+    """Inspect the output DataFrames for integrity violations."""
+    findings = []
+
+    # ── Profiles DataFrame ──────────────────────────────────────────────────
+
+    if not a.profiles.empty:
+        # time_min > time_max (inverted range)
+        for col_pair in [("time_min", "time_max")]:
+            t_min_col, t_max_col = col_pair
+            if t_min_col in a.profiles.columns and t_max_col in a.profiles.columns:
+                try:
+                    t_min = pd.to_datetime(a.profiles[t_min_col], errors="coerce")
+                    t_max = pd.to_datetime(a.profiles[t_max_col], errors="coerce")
+                    inverted = a.profiles[t_min > t_max]
+                    if not inverted.empty:
+                        findings.append(Finding(
+                            severity=HIGH,
+                            category="Data Integrity",
+                            title=f"{len(inverted)} profile(s) have time_min > time_max",
+                            detail="Inverted time ranges indicate a parsing or source-data error.",
+                            affected=_unique_list(inverted, "dataset_id"),
+                            count=len(inverted),
+                        ))
+                except Exception:
+                    pass
+
+        # depth_min > depth_max
+        if "depth_min" in a.profiles.columns and "depth_max" in a.profiles.columns:
+            bad_depth = a.profiles[
+                pd.to_numeric(a.profiles["depth_min"], errors="coerce") >
+                pd.to_numeric(a.profiles["depth_max"], errors="coerce")
+            ]
+            if not bad_depth.empty:
+                findings.append(Finding(
+                    severity=MEDIUM,
+                    category="Data Integrity",
+                    title=f"{len(bad_depth)} profile(s) have depth_min > depth_max",
+                    detail="Inverted depth ranges may indicate altitude variables were incorrectly handled.",
+                    affected=_unique_list(bad_depth, "dataset_id"),
+                    count=len(bad_depth),
+                ))
+
+        # Null in mandatory columns
+        for col in ("latitude", "longitude", "dataset_id", "erddap_url"):
+            if col in a.profiles.columns:
+                null_count = int(a.profiles[col].isna().sum())
+                if null_count:
+                    findings.append(Finding(
+                        severity=HIGH,
+                        category="Data Integrity",
+                        title=f"{null_count} profile row(s) have null '{col}'",
+                        detail=f"'{col}' should never be null in harvested profile output.",
+                        count=null_count,
+                    ))
+
+        # n_records <= 0
+        if "n_records" in a.profiles.columns:
+            bad_records = a.profiles[
+                pd.to_numeric(a.profiles["n_records"], errors="coerce").fillna(0) <= 0
+            ]
+            if not bad_records.empty:
+                findings.append(Finding(
+                    severity=MEDIUM,
+                    category="Data Integrity",
+                    title=f"{len(bad_records)} profile(s) have n_records ≤ 0",
+                    detail="Zero or negative record counts may indicate a counting failure.",
+                    affected=_unique_list(bad_records, "dataset_id"),
+                    count=len(bad_records),
+                ))
+
+    # ── Datasets DataFrame ──────────────────────────────────────────────────
+
+    if not a.datasets.empty:
+        # Duplicate dataset_id rows (caused by EDDTableFromErddap redirects)
+        if "dataset_id" in a.datasets.columns:
+            dupes = a.datasets[a.datasets.duplicated("dataset_id", keep=False)]
+            if not dupes.empty:
+                findings.append(Finding(
+                    severity=MEDIUM,
+                    category="Data Integrity",
+                    title=f"{len(dupes)} duplicate dataset_id rows in datasets output",
+                    detail=(
+                        "Caused by EDDTableFromErddap server-to-server redirects. "
+                        "drop_duplicates() in __main__.py handles this before CSV write."
+                    ),
+                    affected=dupes["dataset_id"].unique().tolist()[:10],
+                    count=len(dupes),
+                ))
+
+        # Datasets with empty eovs list
+        if "eovs" in a.datasets.columns:
+            empty_eovs = a.datasets[
+                a.datasets["eovs"].apply(
+                    lambda v: isinstance(v, list) and len(v) == 0
+                )
+            ]
+            if not empty_eovs.empty:
+                findings.append(Finding(
+                    severity=MEDIUM,
+                    category="Data Integrity",
+                    title=f"{len(empty_eovs)} harvested dataset(s) have an empty eovs list",
+                    detail=(
+                        "A dataset that passed compliance should always have ≥1 EOV. "
+                        "This may indicate a race condition or partial metadata fetch."
+                    ),
+                    affected=_unique_list(empty_eovs, "dataset_id"),
+                    count=len(empty_eovs),
+                ))
+
+    return findings
+
+
+def _check_unhandled_patterns(a) -> list[Finding]:
+    """
+    Scan log messages for patterns that indicate known bugs, edge cases,
+    or code-level error conditions that were gracefully absorbed but should
+    be surfaced in the validation report.
+    """
+    findings = []
+    logs = a.log_capture
+
+    # ── Profiles removed by bad-geometry filter ───────────────────────────
+    bad_geom = logs.search("bad lat/lon") + logs.search("bad geom") + logs.search("removed")
+    bad_geom_msgs = [r for r in bad_geom if r.level in ("WARNING", "ERROR")]
+    if bad_geom_msgs:
+        findings.append(Finding(
+            severity=MEDIUM,
+            category="Data Quality",
+            title=f"Bad-geometry filter removed profiles in {len(bad_geom_msgs)} log event(s)",
+            detail=(
+                "Profiles with lat/lon outside ±90/±180, depth > 15,000m, or null "
+                "records_per_day were discarded. Investigate source data on affected servers."
+            ),
+            count=len(bad_geom_msgs),
+        ))
+
+    # ── Datasets with no profiles after extraction ────────────────────────
+    no_profiles = [r for r in logs.warnings if "no profiles found" in r.message.lower()]
+    if no_profiles:
+        findings.append(Finding(
+            severity=MEDIUM,
+            category="Data Quality",
+            title=f"{len(no_profiles)} compliant dataset(s) produced zero profiles",
+            detail=(
+                "These datasets passed compliance checks but the profile query returned "
+                "nothing. Possible causes: empty ERDDAP dataset, distinct() query timeout, "
+                "or all profiles filtered by bad-geometry rule."
+            ),
+            count=len(no_profiles),
+        ))
+
+    # ── OrderByCount unavailable (old ERDDAP version) ────────────────────
+    orderby = [r for r in logs.errors if "OrderByCount not available" in r.message]
+    if orderby:
+        affected = list({r.logger for r in orderby})
+        findings.append(Finding(
+            severity=MEDIUM,
+            category="Compatibility",
+            title=f"orderByCount unsupported on {len(orderby)} endpoint(s)",
+            detail=(
+                "Older ERDDAP versions do not support orderByCount. "
+                "Affected datasets will have missing record counts (n_records=null)."
+            ),
+            affected=affected,
+            count=len(orderby),
+        ))
+
+    # ── Response size limit hit ───────────────────────────────────────────
+    too_big = (
+        logs.search("response too big") +
+        logs.search("too much data") +
+        logs.search("requesting too much")
+    )
+    too_big = [r for r in too_big if r.level in ("ERROR", "WARNING")]
+    if too_big:
+        findings.append(Finding(
+            severity=MEDIUM,
+            category="Size Limit",
+            title=f"{len(too_big)} request(s) hit the 200 MB response size cap",
+            detail=(
+                "ERDDAP returned a response exceeding MAX_RESPONSE_SIZE (200 MB). "
+                "Affected datasets were skipped. Consider filtering by time range or "
+                "adding them to skipped_datasets.json."
+            ),
+            count=len(too_big),
+        ))
+
+    # ── Non-unique lat/lon within a profile ──────────────────────────────
+    non_unique = [r for r in logs.warnings if "non unique lat/lon" in r.message.lower()]
+    if non_unique:
+        findings.append(Finding(
+            severity=LOW,
+            category="Data Quality",
+            title=f"{len(non_unique)} dataset(s) have profiles with non-unique lat/lon",
+            detail=(
+                "A single profile ID resolves to multiple locations. "
+                "The duplicate is dropped (drop_duplicates on profile_variable_list). "
+                "May indicate incorrect metadata on the source ERDDAP server."
+            ),
+            count=len(non_unique),
+        ))
+
+    # ── Unsupported CF standard names (coverage gap) ─────────────────────
+    uncovered_cf = [r for r in logs.warnings if "standard_names that CDE doesnt support" in r.message]
+    if uncovered_cf:
+        for rec in uncovered_cf[:3]:  # cap at 3 findings to avoid noise
+            findings.append(Finding(
+                severity=INFO,
+                category="Coverage Gap",
+                title="Harvested data contains CF standard names with no CDE EOV mapping",
+                detail=(
+                    f"These valid CF names exist in the data but are not mapped to any "
+                    f"CDE Essential Ocean Variable: {rec.message[:200]}"
+                ),
+                count=1,
+            ))
+
+    # ── Record count HTTP errors (partial data) ───────────────────────────
+    count_errs = [r for r in logs.errors if "HTTP ERROR during count" in r.message]
+    if count_errs:
+        findings.append(Finding(
+            severity=LOW,
+            category="Partial Data",
+            title=f"{len(count_errs)} dataset(s) have missing record counts",
+            detail=(
+                "The orderByCount query failed for these datasets. "
+                "n_records will be null, and records_per_day will not be calculable."
+            ),
+            count=len(count_errs),
+        ))
+
+    # ── Platform vocabulary failures ──────────────────────────────────────
+    plat_errs = [
+        r for r in logs.errors
+        if "unsupported" in r.message.lower() and "platform" in r.message.lower()
+    ]
+    if plat_errs:
+        findings.append(Finding(
+            severity=LOW,
+            category="Vocabulary",
+            title=f"{len(plat_errs)} dataset(s) have unrecognised platform codes",
+            detail=(
+                "Platform codes not found in the IOOS/L06 vocabulary mapping. "
+                "These datasets will have platform='unknown' in the output."
+            ),
+            count=len(plat_errs),
+        ))
+
+    # ── Error counting with time_coverage_resolution ─────────────────────
+    tcr_logs = [r for r in logs.records if "time_coverage_resolution" in r.message]
+    invalid_tcr = [r for r in tcr_logs if "invalid" in r.message.lower() or r.level == "ERROR"]
+    if invalid_tcr:
+        findings.append(Finding(
+            severity=LOW,
+            category="Data Quality",
+            title=f"{len(invalid_tcr)} dataset(s) have an invalid time_coverage_resolution",
+            detail=(
+                "The global attribute time_coverage_resolution could not be parsed as a "
+                "pandas Timedelta. Falling back to sample-based record counting."
+            ),
+            count=len(invalid_tcr),
+        ))
+
+    return findings
+
+
+def _check_performance(a) -> list[Finding]:
+    """Flag unusually slow HTTP requests that may indicate flaky servers."""
+    SLOW_THRESHOLD_S = 30.0
+    findings = []
+
+    slow = [c for c in a.http_tracker.calls if c.elapsed_s > SLOW_THRESHOLD_S]
+    if slow:
+        top5 = sorted(slow, key=lambda c: c.elapsed_s, reverse=True)[:5]
+        detail_lines = [f"  {c.elapsed_s:.1f}s — {c.url[:100]}" for c in top5]
+        findings.append(Finding(
+            severity=LOW,
+            category="Performance",
+            title=f"{len(slow)} HTTP request(s) exceeded {SLOW_THRESHOLD_S:.0f}s",
+            detail="Slowest (top 5):\n" + "\n".join(detail_lines),
+            count=len(slow),
+        ))
+
+    # Single call approaching or exceeding the 200 MB size cap
+    SIZE_WARN_BYTES = 150 * 1024 * 1024  # 150 MB
+    large = [c for c in a.http_tracker.calls if c.size_bytes >= SIZE_WARN_BYTES]
+    if large:
+        top3 = sorted(large, key=lambda c: c.size_bytes, reverse=True)[:3]
+        detail_lines = [f"  {c.size_bytes / 1024 / 1024:.1f} MB — {c.url[:100]}" for c in top3]
+        findings.append(Finding(
+            severity=LOW,
+            category="Performance",
+            title=f"{len(large)} response(s) exceeded 150 MB (approaching the 200 MB cap)",
+            detail="Largest responses:\n" + "\n".join(detail_lines),
+            count=len(large),
+        ))
+
+    return findings
+
+
+def _check_output_completeness(a) -> list[Finding]:
+    findings = []
+    if a.datasets.empty and not a.fatal_error:
+        findings.append(Finding(
+            severity=CRITICAL,
+            category="Empty Output",
+            title="No datasets were harvested — output is completely empty",
+            detail=(
+                "datasets DataFrame is empty despite no fatal error. "
+                "Possible causes: all servers unreachable, all datasets skipped, "
+                "or misconfigured erddap_urls in config."
+            ),
+        ))
+    elif not a.datasets.empty and a.profiles.empty:
+        findings.append(Finding(
+            severity=HIGH,
+            category="Empty Output",
+            title="Datasets were found but no profiles were extracted",
+            detail=(
+                "Every compliant dataset produced zero profiles. "
+                "Profile extraction (get_profiles) may be failing silently."
+            ),
+        ))
+    return findings
+
+
+# ─── Summary builders ─────────────────────────────────────────────────────────
+
+def _skip_breakdown(skipped: pd.DataFrame) -> list[SkipBreakdown]:
+    if skipped.empty:
+        return []
+    total = len(skipped)
+    grouped = skipped.groupby("reason_code")["dataset_id"].apply(list)
+    result = []
+    for reason, ids in grouped.items():
+        result.append(SkipBreakdown(
+            reason_code=reason,
+            count=len(ids),
+            pct=round(100 * len(ids) / total, 1) if total else 0,
+            examples=ids[:5],
+            description=_SKIP_DESCRIPTIONS.get(reason, reason),
+        ))
+    return sorted(result, key=lambda s: s.count, reverse=True)
+
+
+def _http_summary(tracker) -> dict:
+    calls = tracker.calls
+    if not calls:
+        return {"total": 0, "success": 0, "errors": 0, "redirects": 0}
+    ok = [c for c in calls if c.ok]
+    errors = [c for c in calls if not c.ok]
+    times = [c.elapsed_s for c in calls]
+    redirects = [c for c in calls if c.redirected_to]
+    return {
+        "total": len(calls),
+        "success": len(ok),
+        "errors": len(errors),
+        "redirects": len(redirects),
+        "avg_elapsed_s": round(sum(times) / len(times), 2),
+        "max_elapsed_s": round(max(times), 2),
+        "total_mb": round(sum(c.size_bytes for c in calls) / 1024 / 1024, 1),
+        "errors_by_status": _group_counts(errors, lambda c: str(c.status or "connection_error")),
+        "servers_contacted": tracker.unique_servers(),
+    }
+
+
+def _log_summary(capture) -> dict:
+    counts = capture.level_counts()
+    for lvl in ("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"):
+        counts.setdefault(lvl, 0)
+    return counts
+
+
+def _data_summary(a) -> dict:
+    unique_servers = 0
+    if not a.datasets.empty and "erddap_url" in a.datasets.columns:
+        unique_servers = int(a.datasets["erddap_url"].nunique())
+    return {
+        "servers_configured": len(a.config.get("erddap_urls") or []),
+        "servers_with_results": len(a.per_server),
+        "datasets_harvested": len(a.datasets),
+        "datasets_skipped": len(a.skipped),
+        "datasets_total": len(a.datasets) + len(a.skipped),
+        "profiles_extracted": len(a.profiles),
+        "unique_erddap_servers_in_output": unique_servers,
+    }
+
+
+def _per_server_summary(a) -> dict:
+    summary: dict = {}
+    for url, parts in a.per_server.items():
+        profiles_df, datasets_df, _, skipped_df = parts
+        summary[url] = {
+            "datasets_harvested": len(datasets_df),
+            "datasets_skipped": len(skipped_df),
+            "profiles_extracted": len(profiles_df),
+        }
+    return summary
+
+
+def _config_summary(config: dict) -> dict:
+    return {
+        "erddap_server_count": len(config.get("erddap_urls") or []),
+        "erddap_urls": config.get("erddap_urls") or [],
+        "dataset_id_filter": config.get("dataset_ids") or [],
+        "cache_enabled": bool(config.get("cache", False)),
+        "max_workers": config.get("max-workers", 1),
+    }
+
+
+def _error_log_lines(capture) -> list[str]:
+    lines = []
+    for r in capture.errors:
+        line = f"[{r.time}] {r.level:8s} | {r.logger} | {r.message}"
+        lines.append(line)
+        if r.exc_info:
+            for tb_line in r.exc_info.splitlines():
+                lines.append(f"    {tb_line}")
+    return lines
+
+
+# ─── Utilities ────────────────────────────────────────────────────────────────
+
+def _unique_list(df: pd.DataFrame, col: str, limit: int = 10) -> list[str]:
+    if col not in df.columns:
+        return []
+    return df[col].dropna().unique().tolist()[:limit]
+
+
+def _group_counts(items, key_fn) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for item in items:
+        k = key_fn(item)
+        counts[k] = counts.get(k, 0) + 1
+    return counts

--- a/harvester/harvest_validator/collectors.py
+++ b/harvester/harvest_validator/collectors.py
@@ -1,0 +1,201 @@
+"""
+Collectors — lightweight, non-invasive interceptors that capture observational
+data during a live harvest run without modifying the source code under observation.
+
+Both collectors are context managers; they install themselves on entry and restore
+the original state on exit, making them safe to nest and compose.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Optional
+from urllib.parse import urlparse
+
+import requests
+
+
+# ─── Data classes ─────────────────────────────────────────────────────────────
+
+@dataclass
+class CapturedLogRecord:
+    """A single log event captured during the harvest run."""
+    time: str
+    level: str
+    logger: str
+    message: str
+    exc_info: Optional[str] = None
+
+
+@dataclass
+class HttpCall:
+    """One outbound HTTP request made during the harvest."""
+    url: str
+    server: str
+    status: Optional[int]       # None = connection-level error (no response)
+    elapsed_s: float
+    size_bytes: int
+    ok: bool
+    redirected_to: Optional[str] = None
+    error: Optional[str] = None  # populated when status is None
+
+
+# ─── Log interceptor ──────────────────────────────────────────────────────────
+
+class LogCapture(logging.Handler):
+    """
+    Installs on the root logger and captures every log record emitted during
+    the harvest at DEBUG level and above.
+
+    Thread-safe: the harvester runs multiple worker threads concurrently.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(logging.DEBUG)
+        self.records: list[CapturedLogRecord] = []
+        self._lock = threading.Lock()
+        self.setFormatter(logging.Formatter("%(message)s"))
+
+    def emit(self, record: logging.LogRecord) -> None:
+        exc_text: Optional[str] = None
+        if record.exc_info:
+            exc_text = self.formatException(record.exc_info)
+        entry = CapturedLogRecord(
+            time=datetime.fromtimestamp(record.created).isoformat(timespec="seconds"),
+            level=record.levelname,
+            logger=record.name,
+            message=record.getMessage(),
+            exc_info=exc_text,
+        )
+        with self._lock:
+            self.records.append(entry)
+
+    def __enter__(self) -> "LogCapture":
+        logging.getLogger().addHandler(self)
+        return self
+
+    def __exit__(self, *_) -> None:
+        logging.getLogger().removeHandler(self)
+
+    # ── Convenience filters ──────────────────────────────────────────────────
+
+    def by_level(self, level: str) -> list[CapturedLogRecord]:
+        return [r for r in self.records if r.level == level]
+
+    @property
+    def errors(self) -> list[CapturedLogRecord]:
+        return [r for r in self.records if r.level in ("ERROR", "CRITICAL")]
+
+    @property
+    def warnings(self) -> list[CapturedLogRecord]:
+        return [r for r in self.records if r.level == "WARNING"]
+
+    def search(self, text: str) -> list[CapturedLogRecord]:
+        """Case-insensitive substring search across all messages."""
+        lower = text.lower()
+        return [r for r in self.records if lower in r.message.lower()]
+
+    def level_counts(self) -> dict[str, int]:
+        counts: dict[str, int] = {}
+        for r in self.records:
+            counts[r.level] = counts.get(r.level, 0) + 1
+        return counts
+
+
+# ─── HTTP call interceptor ─────────────────────────────────────────────────────
+
+class HttpCallTracker:
+    """
+    Monkey-patches `requests.Session.get` to record the URL, HTTP status,
+    elapsed time, response body size, and redirect target for every request
+    the harvester makes to ERDDAP or CKAN servers.
+
+    Thread-safe: uses a lock to protect the shared call list.
+    """
+
+    def __init__(self) -> None:
+        self.calls: list[HttpCall] = []
+        self._original_get = None
+        self._lock = threading.Lock()
+
+    # ── Context manager ───────────────────────────────────────────────────────
+
+    def __enter__(self) -> "HttpCallTracker":
+        self._original_get = requests.Session.get
+        requests.Session.get = self._build_tracked_get(self._original_get)
+        return self
+
+    def __exit__(self, *_) -> None:
+        if self._original_get is not None:
+            requests.Session.get = self._original_get
+            self._original_get = None
+
+    # ── Internals ─────────────────────────────────────────────────────────────
+
+    def _build_tracked_get(self, original):
+        tracker = self
+
+        def tracked_get(session_self, url: str, **kwargs):
+            server = urlparse(url).netloc
+            t0 = time.perf_counter()
+            try:
+                response = original(session_self, url, **kwargs)
+                elapsed = time.perf_counter() - t0
+                redirected_to: Optional[str] = None
+                if response.url and response.url != url:
+                    redirected_to = response.url
+                call = HttpCall(
+                    url=url,
+                    server=server,
+                    status=response.status_code,
+                    elapsed_s=round(elapsed, 3),
+                    size_bytes=len(response.content),
+                    ok=response.status_code == 200,
+                    redirected_to=redirected_to,
+                )
+            except Exception as exc:
+                elapsed = time.perf_counter() - t0
+                call = HttpCall(
+                    url=url,
+                    server=server,
+                    status=None,
+                    elapsed_s=round(elapsed, 3),
+                    size_bytes=0,
+                    ok=False,
+                    error=str(exc),
+                )
+                with tracker._lock:
+                    tracker.calls.append(call)
+                raise
+
+            with tracker._lock:
+                tracker.calls.append(call)
+            return response
+
+        return tracked_get
+
+    # ── Convenience filters ──────────────────────────────────────────────────
+
+    @property
+    def error_calls(self) -> list[HttpCall]:
+        return [c for c in self.calls if not c.ok]
+
+    @property
+    def redirect_calls(self) -> list[HttpCall]:
+        return [c for c in self.calls if c.redirected_to]
+
+    def calls_for_server(self, server: str) -> list[HttpCall]:
+        return [c for c in self.calls if c.server == server]
+
+    def slowest(self, n: int = 10) -> list[HttpCall]:
+        return sorted(self.calls, key=lambda c: c.elapsed_s, reverse=True)[:n]
+
+    def largest(self, n: int = 10) -> list[HttpCall]:
+        return sorted(self.calls, key=lambda c: c.size_bytes, reverse=True)[:n]
+
+    def unique_servers(self) -> list[str]:
+        return sorted({c.server for c in self.calls})

--- a/harvester/harvest_validator/quick_check.py
+++ b/harvester/harvest_validator/quick_check.py
@@ -1,0 +1,233 @@
+"""
+quick_check.py — fast smoke-test runner for harvest_validator.
+
+Runs the full validation pipeline against a single ERDDAP server and
+optionally a single dataset, then prints the report summary to the
+terminal.  A full report is also written to ./validation_reports/.
+
+Usage examples:
+
+  # Offline mock run (no network, verifies tool plumbing only)
+  python -m harvest_validator.quick_check
+
+  # Real ERDDAP server (all datasets, capped at a short timeout)
+  python -m harvest_validator.quick_check \\
+      --erddap https://data.cioospacific.ca/erddap
+
+  # Real ERDDAP server, single known dataset
+  python -m harvest_validator.quick_check \\
+      --erddap https://data.cioospacific.ca/erddap \\
+      --dataset IOS_BOT_Profiles
+
+  # Real server, write report to a custom directory
+  python -m harvest_validator.quick_check \\
+      --erddap https://catalogue.hakai.org/erddap \\
+      --dataset HakaiKCBuoyResearch \\
+      --output-dir /tmp/my_reports
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+import tempfile
+import textwrap
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import yaml
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)-8s %(name)s : %(message)s",
+    datefmt="%H:%M:%S",
+)
+logger = logging.getLogger("quick_check")
+
+# ─── Mock response for the offline/dry-run mode ────────────────────────────
+
+# Minimal ERDDAP CSV responses that the harvester expects.
+# The allDatasets response has 2 skip-rows (units + type), then zero data rows
+# so no datasets are processed — making the run instant.
+_MOCK_ALL_DATASETS_CSV = (
+    "datasetID,cdm_data_type,accessible,dataStructure\r\n"
+    "(String),(String),(String),(String)\r\n"
+    ",,,\r\n"
+)
+
+
+def _make_mock_response(url: str, text: str = _MOCK_ALL_DATASETS_CSV) -> MagicMock:
+    r = MagicMock()
+    r.status_code = 200
+    r.url = url
+    r.text = text
+    r.content = text.encode()
+    return r
+
+
+def _mock_get(session_self, url: str, **kwargs) -> MagicMock:
+    """Intercepts requests.Session.get (patched at class level, so first arg is self)."""
+    return _make_mock_response(url)
+
+
+# ─── CLI ──────────────────────────────────────────────────────────────────────
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="python -m harvest_validator.quick_check",
+        description="Quick validation smoke-test against a single ERDDAP server.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=textwrap.dedent("""\
+            If --erddap is omitted the tool runs in OFFLINE mode using mocked
+            HTTP responses.  No network calls are made; this verifies that the
+            validator itself is correctly installed and operational.
+
+            If --erddap is supplied the tool makes real HTTP calls to that server.
+            Use --dataset to restrict to a single known dataset ID for a faster run.
+        """),
+    )
+    p.add_argument(
+        "--erddap",
+        metavar="URL",
+        default=None,
+        help="ERDDAP base URL (e.g. https://data.cioospacific.ca/erddap). "
+             "Omit for offline mock mode.",
+    )
+    p.add_argument(
+        "--dataset",
+        metavar="ID",
+        default=None,
+        help="Limit harvest to a single dataset ID (faster for spot-checks).",
+    )
+    p.add_argument(
+        "--output-dir",
+        metavar="DIR",
+        default="./validation_reports",
+        help="Base directory for report output (default: ./validation_reports).",
+    )
+    p.add_argument(
+        "--no-cache",
+        action="store_true",
+        default=False,
+        help="Disable disk cache (default: cache enabled when offline, disabled online).",
+    )
+    return p
+
+
+# ─── Entry point ──────────────────────────────────────────────────────────────
+
+def main(argv=None) -> int:
+    args = build_parser().parse_args(argv)
+
+    offline = args.erddap is None
+    run_id = datetime.now().strftime("%Y%m%d_%H%M%S")
+
+    if offline:
+        logger.info("Running in OFFLINE mode (mocked HTTP responses, no network calls).")
+    else:
+        logger.info("Running against ERDDAP server: %s", args.erddap)
+        if args.dataset:
+            logger.info("Limiting to dataset: %s", args.dataset)
+
+    # ── Build config ──────────────────────────────────────────────────────────
+    erddap_url = args.erddap or "https://mock.erddap.local/erddap"
+    config: dict = {
+        "erddap_urls": [erddap_url],
+        "cache": False,  # never cache in quick_check; avoids diskcache side-effects
+        "max-workers": 1,
+    }
+    if args.dataset:
+        config["dataset_ids"] = [args.dataset]
+
+    output_dir = Path(args.output_dir)
+
+    # ── Run (with or without mock) ────────────────────────────────────────────
+    from harvest_validator.runner import HarvestRunner
+    from harvest_validator.analyzers import analyze, CRITICAL, HIGH
+    from harvest_validator.reporter import ReportWriter
+
+    runner = HarvestRunner(config, run_id)
+
+    if offline:
+        with patch("requests.Session.get", _mock_get):
+            artifacts = runner.run()
+    else:
+        artifacts = runner.run()
+
+    # ── Analyze and report ────────────────────────────────────────────────────
+    logger.info(
+        "Harvest finished in %s — %d dataset(s), %d profile(s), %d skipped, "
+        "%d HTTP call(s)",
+        artifacts.duration_human,
+        len(artifacts.datasets),
+        len(artifacts.profiles),
+        len(artifacts.skipped),
+        len(artifacts.http_tracker.calls),
+    )
+
+    analysis = analyze(artifacts)
+
+    report_dir = output_dir / run_id
+    writer = ReportWriter(report_dir)
+    try:
+        writer.write(analysis, artifacts.log_capture)
+        logger.info("Report verified (JSON structure, Markdown sections, JSONL integrity).")
+    except ValueError as exc:
+        logger.error("REPORT VERIFICATION FAILED: %s", exc)
+        return 2
+
+    # ── Terminal summary ───────────────────────────────────────────────────────
+    _print_summary(analysis, report_dir, offline)
+
+    critical_count = sum(1 for f in analysis.findings if f.severity == CRITICAL)
+    high_count     = sum(1 for f in analysis.findings if f.severity == HIGH)
+
+    return 1 if (critical_count or high_count) else 0
+
+
+def _print_summary(analysis, report_dir: Path, offline: bool) -> None:
+    from harvest_validator.analyzers import CRITICAL, HIGH, MEDIUM, LOW, INFO
+
+    mode = "OFFLINE MOCK" if offline else "LIVE"
+    print()
+    print("═" * 62)
+    print(f"  HARVEST VALIDATION QUICK-CHECK  [{mode}]")
+    print(f"  Run ID: {analysis.run_id}")
+    print("═" * 62)
+
+    ds = analysis.data_summary
+    hs = analysis.http_summary
+    print(f"  Servers configured : {ds.get('servers_configured', 0)}")
+    print(f"  Datasets harvested : {ds.get('datasets_harvested', 0)}")
+    print(f"  Datasets skipped   : {ds.get('datasets_skipped', 0)}")
+    print(f"  Profiles extracted : {ds.get('profiles_extracted', 0):,}")
+    print(f"  HTTP calls made    : {hs.get('total', 0)}")
+    print(f"  Duration           : {analysis.duration_human}")
+    print()
+
+    if not analysis.findings:
+        print("  ✓ No issues detected.")
+    else:
+        for sev in (CRITICAL, HIGH, MEDIUM, LOW, INFO):
+            bucket = [f for f in analysis.findings if f.severity == sev]
+            if not bucket:
+                continue
+            print(f"  [{sev:8s}] {len(bucket)} finding(s):")
+            for f in bucket:
+                print(f"    • [{f.category}] {f.title}")
+                if f.count:
+                    print(f"      count={f.count}" + (f", affected={f.affected[:3]}" if f.affected else ""))
+
+    print()
+    print(f"  Full report: {report_dir}/")
+    print(f"    report.md    — human-readable Markdown")
+    print(f"    report.json  — machine-readable data")
+    print(f"    events.jsonl — full log event stream")
+    print("═" * 62)
+    print()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/harvester/harvest_validator/reporter.py
+++ b/harvester/harvest_validator/reporter.py
@@ -1,0 +1,405 @@
+"""
+ReportWriter — generates per-run validation reports from a HarvestAnalysis.
+
+Three output files are written to a timestamped subdirectory:
+  report.md     — human-readable Markdown report for engineers and git tracking
+  report.json   — machine-readable structured data for downstream tooling
+  events.jsonl  — every captured log record (one JSON object per line)
+
+Report sections
+───────────────
+  1. Header and executive summary table
+  2. Findings — severity-grouped, with detail and affected IDs
+  3. Skip analysis — per reason-code breakdown
+  4. Per-server breakdown
+  5. HTTP API call statistics
+  6. Log event counts
+  7. Error log entries (verbatim)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import dataclasses
+from dataclasses import asdict
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+from .analyzers import (
+    CRITICAL, HIGH, MEDIUM, LOW, INFO,
+    Finding, HarvestAnalysis,
+)
+from .collectors import CapturedLogRecord
+
+# ─── Severity display ─────────────────────────────────────────────────────────
+
+_SEVERITY_PREFIX = {
+    CRITICAL: "### CRITICAL",
+    HIGH:     "### HIGH",
+    MEDIUM:   "### MEDIUM",
+    LOW:      "### LOW",
+    INFO:     "### INFO",
+}
+
+_SEVERITY_BADGE = {
+    CRITICAL: "[CRITICAL]",
+    HIGH:     "[HIGH]    ",
+    MEDIUM:   "[MEDIUM]  ",
+    LOW:      "[LOW]     ",
+    INFO:     "[INFO]    ",
+}
+
+
+# ─── Writer ───────────────────────────────────────────────────────────────────
+
+class ReportWriter:
+    """
+    Writes report.md, report.json, and events.jsonl to `output_dir`.
+    """
+
+    def __init__(self, output_dir: str | Path) -> None:
+        self.output_dir = Path(output_dir)
+
+    def write(self, analysis: HarvestAnalysis, log_capture) -> Path:
+        """
+        Write all three output files and return the directory path.
+        """
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+
+        md_path   = self.output_dir / "report.md"
+        json_path = self.output_dir / "report.json"
+        jsonl_path = self.output_dir / "events.jsonl"
+
+        md_path.write_text(self._build_markdown(analysis), encoding="utf-8")
+        json_content = self._build_json(analysis)
+        json_path.write_text(json_content, encoding="utf-8")
+        self._write_jsonl(log_capture, jsonl_path)
+
+        # Self-verify: re-parse the written files and assert structural integrity.
+        # Any validation error is raised immediately so the caller knows the
+        # report is corrupt before the run is considered complete.
+        self._verify_json(json_path, json_content, analysis)
+        self._verify_markdown(md_path)
+        self._verify_jsonl(jsonl_path, log_capture)
+
+        return self.output_dir
+
+    # ── Report self-verification ──────────────────────────────────────────────
+
+    # Top-level keys that must be present in every valid report.json
+    _REQUIRED_JSON_KEYS = {
+        "run_id", "start_time", "end_time", "duration_s", "duration_human",
+        "config_summary", "findings", "skip_breakdown",
+        "http_summary", "log_summary", "data_summary",
+        "per_server_summary", "error_log_lines",
+    }
+
+    # Mandatory data_summary keys
+    _REQUIRED_DATA_SUMMARY_KEYS = {
+        "servers_configured", "datasets_harvested", "datasets_skipped",
+        "profiles_extracted",
+    }
+
+    def _verify_json(self, path: Path, raw: str, analysis: HarvestAnalysis) -> None:
+        """
+        Parse report.json and assert required structure.
+        Raises ValueError with a clear description on any violation.
+        """
+        try:
+            parsed = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"report.json is not valid JSON: {exc}") from exc
+
+        missing_keys = self._REQUIRED_JSON_KEYS - set(parsed.keys())
+        if missing_keys:
+            raise ValueError(f"report.json missing required keys: {missing_keys}")
+
+        data_summary = parsed.get("data_summary", {})
+        missing_ds = self._REQUIRED_DATA_SUMMARY_KEYS - set(data_summary.keys())
+        if missing_ds:
+            raise ValueError(f"report.json data_summary missing keys: {missing_ds}")
+
+        if not isinstance(parsed["findings"], list):
+            raise ValueError("report.json 'findings' must be a list")
+
+        if not isinstance(parsed["skip_breakdown"], list):
+            raise ValueError("report.json 'skip_breakdown' must be a list")
+
+        # Cross-check: findings count in file must match analysis object
+        if len(parsed["findings"]) != len(analysis.findings):
+            raise ValueError(
+                f"report.json findings count ({len(parsed['findings'])}) "
+                f"does not match analysis ({len(analysis.findings)})"
+            )
+
+        # Ensure every finding has required fields
+        for i, finding in enumerate(parsed["findings"]):
+            for field_name in ("severity", "category", "title", "detail"):
+                if field_name not in finding:
+                    raise ValueError(
+                        f"report.json findings[{i}] missing field '{field_name}'"
+                    )
+
+    def _verify_markdown(self, path: Path) -> None:
+        """Assert that report.md was written and contains the expected section headers."""
+        content = path.read_text(encoding="utf-8")
+        required_sections = [
+            "# Harvest Validation Report",
+            "## Executive Summary",
+            "## Findings",
+        ]
+        for section in required_sections:
+            if section not in content:
+                raise ValueError(
+                    f"report.md is missing expected section: '{section}'"
+                )
+
+    def _verify_jsonl(self, path: Path, log_capture) -> None:
+        """Assert events.jsonl contains one valid JSON object per line."""
+        lines = path.read_text(encoding="utf-8").splitlines()
+        expected_count = len(log_capture.records)
+        if len(lines) != expected_count:
+            raise ValueError(
+                f"events.jsonl has {len(lines)} lines but {expected_count} log records were captured"
+            )
+        for i, line in enumerate(lines):
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"events.jsonl line {i+1} is not valid JSON: {exc}") from exc
+            for field_name in ("time", "level", "logger", "message"):
+                if field_name not in obj:
+                    raise ValueError(
+                        f"events.jsonl line {i+1} missing field '{field_name}'"
+                    )
+
+    # ── Markdown ──────────────────────────────────────────────────────────────
+
+    def _build_markdown(self, a: HarvestAnalysis) -> str:
+        parts = [
+            self._md_header(a),
+            self._md_executive_summary(a),
+            self._md_findings(a),
+            self._md_skip_breakdown(a),
+            self._md_per_server(a),
+            self._md_http_summary(a),
+            self._md_log_summary(a),
+            self._md_error_log(a),
+        ]
+        return "\n\n".join(p for p in parts if p)
+
+    def _md_header(self, a: HarvestAnalysis) -> str:
+        return (
+            f"# Harvest Validation Report\n\n"
+            f"**Run ID:** `{a.run_id}`  \n"
+            f"**Started:** {a.start_time}  \n"
+            f"**Ended:**   {a.end_time}  \n"
+            f"**Duration:** {a.duration_human}  \n"
+            f"**ERDDAP servers configured:** {a.config_summary['erddap_server_count']}  \n"
+            f"**Dataset ID filter active:** {'Yes' if a.config_summary['dataset_id_filter'] else 'No'}  \n"
+            f"**Cache enabled:** {a.config_summary['cache_enabled']}"
+        )
+
+    def _md_executive_summary(self, a: HarvestAnalysis) -> str:
+        ds = a.data_summary
+        hs = a.http_summary
+        total = ds.get("datasets_total", 0)
+        harvested = ds.get("datasets_harvested", 0)
+        harvest_pct = f"{100 * harvested / total:.1f}%" if total else "N/A"
+
+        severity_counts = _count_by_severity(a.findings)
+        finding_summary = "  ".join(
+            f"{_SEVERITY_BADGE[sev].strip()}: {severity_counts.get(sev, 0)}"
+            for sev in (CRITICAL, HIGH, MEDIUM, LOW, INFO)
+        )
+
+        lines = [
+            "## Executive Summary",
+            "",
+            "| Metric | Value |",
+            "|--------|-------|",
+            f"| Servers configured | {ds.get('servers_configured', 0)} |",
+            f"| Servers with results | {ds.get('servers_with_results', 0)} |",
+            f"| Datasets discovered | {total} |",
+            f"| Datasets harvested | {harvested} ({harvest_pct}) |",
+            f"| Datasets skipped | {ds.get('datasets_skipped', 0)} |",
+            f"| Profiles extracted | {ds.get('profiles_extracted', 0):,} |",
+            f"| HTTP calls | {hs.get('total', 0):,} |",
+            f"| HTTP errors | {hs.get('errors', 0)} ({_pct(hs.get('errors', 0), hs.get('total', 0))}) |",
+            f"| Run duration | {a.duration_human} |",
+            "",
+            f"**Findings:** {finding_summary}",
+        ]
+        return "\n".join(lines)
+
+    def _md_findings(self, a: HarvestAnalysis) -> str:
+        if not a.findings:
+            return "## Findings\n\nNo issues detected."
+
+        by_severity: dict[str, list[Finding]] = {}
+        for f in a.findings:
+            by_severity.setdefault(f.severity, []).append(f)
+
+        sections = ["## Findings\n"]
+        for sev in (CRITICAL, HIGH, MEDIUM, LOW, INFO):
+            bucket = by_severity.get(sev, [])
+            prefix = _SEVERITY_PREFIX[sev]
+            if not bucket:
+                sections.append(f"{prefix} (0)\n\n*(none)*")
+                continue
+            sections.append(f"{prefix} ({len(bucket)})\n")
+            for f in bucket:
+                sections.append(f"**[{f.category}]** {f.title}")
+                sections.append(f"> {f.detail}")
+                if f.affected:
+                    shown = f.affected[:5]
+                    more = len(f.affected) - len(shown)
+                    aff = ", ".join(f"`{x}`" for x in shown)
+                    if more:
+                        aff += f" *(+{more} more)*"
+                    sections.append(f"Affected: {aff}")
+                sections.append("")
+
+        return "\n".join(sections)
+
+    def _md_skip_breakdown(self, a: HarvestAnalysis) -> str:
+        if not a.skip_breakdown:
+            return "## Skip Analysis\n\nNo datasets were skipped."
+
+        total_skipped = sum(s.count for s in a.skip_breakdown)
+        rows = [
+            "## Skip Analysis",
+            "",
+            f"Total skipped: **{total_skipped}**",
+            "",
+            "| Reason Code | Count | % | Description |",
+            "|-------------|-------|---|-------------|",
+        ]
+        for s in a.skip_breakdown:
+            rows.append(
+                f"| `{s.reason_code}` | {s.count} | {s.pct}% | {s.description} |"
+            )
+
+        # Sample affected datasets per reason
+        rows += ["", "**Examples per reason:**", ""]
+        for s in a.skip_breakdown:
+            if s.examples:
+                rows.append(f"- `{s.reason_code}`: " + ", ".join(f"`{x}`" for x in s.examples))
+
+        return "\n".join(rows)
+
+    def _md_per_server(self, a: HarvestAnalysis) -> str:
+        if not a.per_server_summary:
+            return ""
+
+        rows = [
+            "## Per-Server Breakdown",
+            "",
+            "| Server | Datasets Harvested | Datasets Skipped | Profiles Extracted |",
+            "|--------|--------------------|------------------|--------------------|",
+        ]
+        for url, stats in sorted(a.per_server_summary.items()):
+            server = _server_label(url)
+            rows.append(
+                f"| {server} | {stats['datasets_harvested']} "
+                f"| {stats['datasets_skipped']} "
+                f"| {stats['profiles_extracted']:,} |"
+            )
+        return "\n".join(rows)
+
+    def _md_http_summary(self, a: HarvestAnalysis) -> str:
+        hs = a.http_summary
+        if not hs.get("total"):
+            return "## HTTP API Calls\n\n*(no calls recorded)*"
+
+        lines = [
+            "## HTTP API Calls",
+            "",
+            f"- **Total:** {hs['total']:,}",
+            f"- **Success (200):** {hs['success']:,} ({_pct(hs['success'], hs['total'])})",
+            f"- **Errors:** {hs['errors']} ({_pct(hs['errors'], hs['total'])})",
+            f"- **Redirects (EDDTableFromErddap):** {hs['redirects']}",
+            f"- **Avg response time:** {hs.get('avg_elapsed_s', 0):.2f}s",
+            f"- **Max response time:** {hs.get('max_elapsed_s', 0):.2f}s",
+            f"- **Total data transferred:** {hs.get('total_mb', 0):.1f} MB",
+        ]
+        if hs.get("errors_by_status"):
+            lines.append("")
+            lines.append("**Error breakdown by status:**")
+            for status, count in sorted(hs["errors_by_status"].items()):
+                lines.append(f"  - HTTP {status}: {count}")
+
+        if hs.get("servers_contacted"):
+            lines += ["", "**Servers contacted:**"]
+            for srv in hs["servers_contacted"]:
+                lines.append(f"  - `{srv}`")
+
+        return "\n".join(lines)
+
+    def _md_log_summary(self, a: HarvestAnalysis) -> str:
+        ls = a.log_summary
+        lines = [
+            "## Log Event Summary",
+            "",
+            "| Level | Count |",
+            "|-------|-------|",
+        ]
+        for level in ("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"):
+            lines.append(f"| {level} | {ls.get(level, 0):,} |")
+        return "\n".join(lines)
+
+    def _md_error_log(self, a: HarvestAnalysis) -> str:
+        if not a.error_log_lines:
+            return "## Error Log Entries\n\n*(no ERROR or CRITICAL events)*"
+
+        lines = [
+            "## Error Log Entries",
+            "",
+            "```",
+        ]
+        lines += a.error_log_lines[:200]  # cap at 200 lines
+        if len(a.error_log_lines) > 200:
+            lines.append(f"... ({len(a.error_log_lines) - 200} more lines truncated — see events.jsonl)")
+        lines.append("```")
+        return "\n".join(lines)
+
+    # ── JSON ──────────────────────────────────────────────────────────────────
+
+    def _build_json(self, a: HarvestAnalysis) -> str:
+        def _to_serialisable(obj):
+            if dataclasses.is_dataclass(obj):
+                return asdict(obj)
+            raise TypeError(f"Not serialisable: {type(obj)}")
+
+        return json.dumps(asdict(a), indent=2, default=str)
+
+    # ── JSONL event log ───────────────────────────────────────────────────────
+
+    def _write_jsonl(self, log_capture, path: Path) -> None:
+        with path.open("w", encoding="utf-8") as fh:
+            for r in log_capture.records:
+                fh.write(json.dumps(asdict(r)) + "\n")
+
+
+# ─── Utilities ────────────────────────────────────────────────────────────────
+
+def _pct(part: int, total: int) -> str:
+    if not total:
+        return "N/A"
+    return f"{100 * part / total:.1f}%"
+
+
+def _count_by_severity(findings: list[Finding]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for f in findings:
+        counts[f.severity] = counts.get(f.severity, 0) + 1
+    return counts
+
+
+def _server_label(url: str) -> str:
+    """Extract the hostname from an ERDDAP URL for compact table display."""
+    from urllib.parse import urlparse
+    parsed = urlparse(url)
+    return parsed.netloc or url[:60]

--- a/harvester/harvest_validator/runner.py
+++ b/harvester/harvest_validator/runner.py
@@ -1,0 +1,190 @@
+"""
+HarvestRunner — orchestrates a fully-instrumented harvest run.
+
+Runs the same harvest_erddap() function used in production while
+LogCapture and HttpCallTracker are active, then bundles every artifact
+(DataFrames, log records, HTTP calls) into a HarvestArtifacts object
+for downstream analysis.
+"""
+
+from __future__ import annotations
+
+import queue
+import threading
+import time
+import traceback
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Optional
+
+import pandas as pd
+
+from cde_harvester.harvest_erddap import harvest_erddap
+from cde_harvester.ckan.create_ckan_erddap_link import get_ckan_records
+
+from .collectors import LogCapture, HttpCallTracker
+
+
+# ─── Artifacts data class ──────────────────────────────────────────────────────
+
+@dataclass
+class HarvestArtifacts:
+    """
+    Everything produced and observed during a single validation run.
+    Passed intact to the analyzer.
+    """
+    run_id: str
+    config: dict
+    start_time: datetime
+    end_time: datetime
+
+    # Output DataFrames (aggregated across all servers)
+    profiles: pd.DataFrame
+    datasets: pd.DataFrame
+    variables: pd.DataFrame
+    skipped: pd.DataFrame
+
+    # Instrumentation captures
+    log_capture: LogCapture
+    http_tracker: HttpCallTracker
+
+    # Per-server breakdown: url → [profiles_df, datasets_df, variables_df, skipped_df]
+    per_server: dict = field(default_factory=dict)
+
+    # Set if the harvest loop itself crashed (not individual dataset errors)
+    fatal_error: Optional[str] = None
+
+    @property
+    def duration_s(self) -> float:
+        return (self.end_time - self.start_time).total_seconds()
+
+    @property
+    def duration_human(self) -> str:
+        secs = int(self.duration_s)
+        if secs < 60:
+            return f"{secs}s"
+        m, s = divmod(secs, 60)
+        if m < 60:
+            return f"{m}m {s:02d}s"
+        h, m = divmod(m, 60)
+        return f"{h}h {m:02d}m {s:02d}s"
+
+
+# ─── Runner ────────────────────────────────────────────────────────────────────
+
+class HarvestRunner:
+    """
+    Runs the harvest pipeline with all collectors active, then returns a
+    fully-populated HarvestArtifacts.
+
+    The runner intentionally mirrors the threading model used in
+    cde_harvester/__main__.py so that the validation run exercises the
+    same code paths as production.
+    """
+
+    def __init__(self, config: dict, run_id: str) -> None:
+        self.config = config
+        self.run_id = run_id
+        self.log_capture = LogCapture()
+        self.http_tracker = HttpCallTracker()
+
+    def run(self) -> HarvestArtifacts:
+        """
+        Execute the harvest with instrumentation and return HarvestArtifacts.
+        Never raises — fatal errors are captured inside the artifact.
+        """
+        erddap_urls: list[str] = self.config.get("erddap_urls") or []
+        limit_ids: Optional[list[str]] = (
+            self.config.get("dataset_ids") or None
+        )
+        cache: bool = bool(self.config.get("cache", False))
+        max_workers: int = int(self.config.get("max-workers", 1))
+
+        per_server: dict = {}
+        all_results: list = []
+        fatal_error: Optional[str] = None
+        start = datetime.now()
+
+        with self.log_capture, self.http_tracker:
+            try:
+                self._run_threaded(
+                    erddap_urls, limit_ids, cache, max_workers,
+                    per_server, all_results,
+                )
+            except Exception:
+                fatal_error = traceback.format_exc()
+
+        end = datetime.now()
+
+        profiles = _concat([r[0] for r in all_results])
+        datasets = _concat([r[1] for r in all_results])
+        variables = _concat([r[2] for r in all_results])
+        skipped = _concat([r[3] for r in all_results])
+
+        return HarvestArtifacts(
+            run_id=self.run_id,
+            config=self.config,
+            start_time=start,
+            end_time=end,
+            profiles=profiles,
+            datasets=datasets,
+            variables=variables,
+            skipped=skipped,
+            log_capture=self.log_capture,
+            http_tracker=self.http_tracker,
+            per_server=per_server,
+            fatal_error=fatal_error,
+        )
+
+    # ── Internal threading ────────────────────────────────────────────────────
+
+    def _run_threaded(
+        self,
+        erddap_urls: list[str],
+        limit_ids: Optional[list[str]],
+        cache: bool,
+        max_workers: int,
+        per_server: dict,
+        all_results: list,
+    ) -> None:
+        """
+        Mirrors the queue + daemon-thread pattern from cde_harvester/__main__.py
+        so the validation run exercises the same concurrency model.
+        """
+        q: queue.Queue = queue.Queue()
+        lock = threading.Lock()
+
+        def worker() -> None:
+            while True:
+                (url, limit, use_cache) = q.get()
+                try:
+                    server_result: list = []
+                    harvest_erddap(url, server_result, limit, use_cache)
+                    if server_result:
+                        with lock:
+                            per_server[url] = server_result[0]
+                            all_results.append(server_result[0])
+                except Exception:
+                    pass  # logged by harvest_erddap; captured by LogCapture
+                finally:
+                    time.sleep(0.1)
+                    q.task_done()
+
+        for _ in range(max(1, max_workers)):
+            t = threading.Thread(target=worker, daemon=True)
+            t.start()
+
+        for url in erddap_urls:
+            q.put((url, limit_ids, cache))
+
+        q.join()
+
+
+# ─── Helpers ──────────────────────────────────────────────────────────────────
+
+def _concat(frames: list) -> pd.DataFrame:
+    """Concatenate a list of DataFrames, ignoring None and empty frames."""
+    non_empty = [f for f in frames if f is not None and len(f) > 0]
+    if not non_empty:
+        return pd.DataFrame()
+    return pd.concat(non_empty, ignore_index=True)

--- a/harvester/pyproject.toml
+++ b/harvester/pyproject.toml
@@ -25,7 +25,7 @@ requires = ["hatchling >= 1.26"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
-packages = ["cde_harvester"]
+packages = ["cde_harvester", "harvest_validator"]
 
 [tool.uv.sources]
 db-loader = { path = "../db-loader" }

--- a/harvester/uml_diagram.txt
+++ b/harvester/uml_diagram.txt
@@ -1,0 +1,150 @@
+================================================================================
+                        CDE Harvester Architecture UML
+================================================================================
+
+                            +------------------------+
+                            |      CLI Entry Point   |
+                            |   cde_harvester/__main__|
+                            +------------+-----------+
+                                         |
+                                         v
++-----------------------------------------------------------------------------+
+|                              Prefect Flows                                   |
++-----------------------------------------------------------------------------+
+
+    +---------------------+         +---------------------+
+    |  main (flow)        |         |  cde_pipeline       |
+    |  (harvester only)   |         |  (full pipeline)   |
+    +---------+-----------+         +----------+----------+
+              |                                  |
+              |  Submits                         |  Orchestrates
+              v                                  v
+    +---------------------+         +---------------------+
+    | harvest_erddap      |         | +---------------+  |
+    | (task)              |         | |harvester_main |--+---> db_loader
+    +---------+-----------+         | +---------------+  |
+              |                      | +---------------+  |
+              |                      | |db_loader_main |--+---> redisFlow
+              v                      | +---------------+  |
+    +---------------------+         +---------------------+
+    | harvest_erddap()    |
+    | (per ERDDAP server) |
+    +---------------------+
+
++-----------------------------------------------------------------------------+
+|                         External Systems                                     |
++-----------------------------------------------------------------------------+
+
+    +--------------------+      +--------------------+      +------------------+
+    |   ERDDAP Server    |      |  CDECompliance     |      |     CKAN API     |
+    |    (External)      |      |     Checker        |      |    (External)   |
+    +--------+-----------+      +--------+-----------+      +---------+--------+
+             |                           |                         |
+             | get_dataset()            | passes_all_checks()    | get_ckan_records()
+             |                           |                         |
+             v                           |                         v
+    +--------------------+              |                 +------------------+
+    |      Dataset       |<-------------+                 |  CKAN Records    |
+    |     [Model]        |                                +------------------+
+    +--------------------+
+
++-----------------------------------------------------------------------------+
+|                           Dataset Class                                      |
++-----------------------------------------------------------------------------+
+
+    Attributes:
+      - id, erddap_url, cdm_data_type
+      - globals (dict), platform, eovs, organizations
+      - df_variables, profile_ids, timeseries_id_variable
+      - profile_id_variable, trajectory_id_variable
+
+    Methods:
+      + get_metadata()          - Fetch dataset/variable metadata
+      + get_eovs()             - Extract EOVs from standard names
+      + get_platform_code()    - Map platform to L06 category
+      + get_profile_ids()     - Extract profile/timeseries identifiers
+      + get_max_min()         - Get spatial/temporal bounds
+      + get_count()           - Count records per profile
+      + get_df()              - Return DataFrame for output
+
++-----------------------------------------------------------------------------+
+|                           ERDDAP Class                                       |
++-----------------------------------------------------------------------------+
+
+    Attributes:
+      - url, domain, cache_requests, cache (diskcache)
+      - session (requests), df_all_datasets
+
+    Methods:
+      + __init__(url, cache)         - Initialize & fetch all datasets
+      + get_all_datasets()           - Fetch list of datasets from server
+      + erddap_csv_to_df(url)        - Convert ERDDAP CSV response to DF
+      + get_dataset(id)               - Create Dataset instance
+
++-----------------------------------------------------------------------------+
+|                          Data Output Flow                                    |
++-----------------------------------------------------------------------------+
+
+      +-------------+    +-------------+    +-------------+    +-------------+
+      |  datasets   |    |  profiles   |    |    ckan    |    |  skipped   |
+      |   .csv      |    |   .csv      |    |   .csv     |    |   .csv     |
+      +------+------+    +------+------+    +------+------+    +------+------+
+             |                   |                   |                   |
+             +-------------------+---------+---------+-------------------+
+                                     |
+                                     v
+                        +-------------------------+
+                        |    PostgreSQL Database  |
+                        |    (via db-loader)     |
+                        +------------+------------+
+                                     |
+                                     v
+                        +-------------------------+
+                        |      Redis Cache        |
+                        |    (redisFunctions)    |
+                        +-------------------------+
+
+================================================================================
+                          Key Classes Summary                                   |
+================================================================================
+
+  Class                  | File                      | Responsibility
+  -----------------------|---------------------------|--------------------------
+  ERDDAP                 | ERDDAP.py                 | Client for ERDDAP server
+  Dataset                | dataset.py                | Model for dataset
+  CDEComplianceChecker   | CDEComplianceChecker.py   | Validates CF compliance
+  harvest_erddap          | harvest_erddap.py        | Prefect task orchestrator
+  get_ckan_records       | ckan/create_ckan_...     | Fetches CKAN metadata
+  redisFlow              | redisFunctions.py         | Refreshes Redis cache
+
+================================================================================
+                            Main Flow Overview                                  |
+================================================================================
+
+1. CLI/ Prefect calls harvester_main()
+
+2. For each ERDDAP URL:
+   - harvest_erddap() task runs
+   - Fetch all datasets from server
+   - Filter by CDM data type (TimeSeries, Profile, TimeSeriesProfile)
+   - Iterate through each dataset
+
+3. For each dataset:
+   - Create Dataset instance
+   - CDEComplianceChecker validates compliance
+   - If valid: extract profiles, metadata, variables
+   - If invalid: add to skipped list
+
+4. Query CKAN for additional metadata
+
+5. Output CSV files:
+   - datasets.csv    - Dataset metadata
+   - profiles.csv    - Profile information
+   - ckan.csv        - CKAN metadata
+   - skipped.csv     - Skipped datasets with reasons
+
+6. db-loader loads CSV to PostgreSQL
+
+7. redisFlow refreshes Redis cache
+
+================================================================================

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,508 @@
+"""
+Shared fixtures and mock data for the CIOOS harvester test suite.
+
+All ERDDAP response fixtures are constructed to match the exact CSV format that
+the real ERDDAP servers return, including the units row that gets skipped by
+erddap_csv_to_df (skiprows=[1] for tabledap, skiprows=[] for /info/).
+"""
+
+import logging
+from io import StringIO
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+# ---------------------------------------------------------------------------
+# Sentry guard — sentry_sdk 2.x raises BadDsn when dsn="" (its silent fallback
+# for dsn=None).  Patch init before any __main__ module is imported so module-
+# level sentry_sdk.init() calls in the source tree are no-ops in tests.
+# ---------------------------------------------------------------------------
+_sentry_init_patcher = patch("sentry_sdk.init")
+_sentry_init_patcher.start()
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+ERDDAP_URL = "https://test.erddap.com/erddap"
+DOMAIN = "test.erddap.com"
+DATASET_ID = "test_timeseries_001"
+DATASET_ID_2 = "test_profile_001"
+
+# Standard names that map to CDE EOVs (pulled from goos_eov_to_standard_name.json)
+SUPPORTED_STANDARD_NAME = "sea_water_temperature"
+UNSUPPORTED_STANDARD_NAME = "some_completely_fake_variable_xyz"
+
+
+# ---------------------------------------------------------------------------
+# ERDDAP CSV response fixtures
+# Each multi-line string represents the raw HTTP response body.
+# ---------------------------------------------------------------------------
+
+# allDatasets endpoint — skiprows=[1, 2] skips the units row and type-hint row.
+ERDDAP_ALL_DATASETS_CSV = """\
+datasetID,cdm_data_type,accessible,dataStructure
+(String),(String),(String),(String)
+,,,
+test_timeseries_001,TimeSeries,public,table
+test_profile_001,Profile,public,table
+test_unsupported_001,Point,public,table
+"""
+
+# /info/{id}/index.csv — skiprows=[] so the header is row 0, data starts row 1.
+# Columns: Row Type | Variable Name | Attribute Name | Data Type | Value
+ERDDAP_INFO_CSV = """\
+Row Type,Variable Name,Attribute Name,Data Type,Value
+attribute,NC_GLOBAL,cdm_data_type,,TimeSeries
+attribute,NC_GLOBAL,title,,Test Temperature Dataset
+attribute,NC_GLOBAL,institution,,Test Institution
+variable,time,,double,
+attribute,time,actual_range,,"2020-01-01T00:00:00Z,2025-01-01T00:00:00Z"
+variable,latitude,,double,
+variable,longitude,,double,
+variable,depth,,double,
+attribute,depth,actual_range,,"0.5,200.5"
+variable,temperature,,double,
+attribute,temperature,standard_name,,sea_water_temperature
+variable,station_id,,String,
+attribute,station_id,cf_role,,timeseries_id
+"""
+
+# Info CSV for a dataset that has no supported EOVs
+ERDDAP_INFO_NO_EOVS_CSV = """\
+Row Type,Variable Name,Attribute Name,Data Type,Value
+attribute,NC_GLOBAL,cdm_data_type,,TimeSeries
+attribute,NC_GLOBAL,title,,No EOV Dataset
+attribute,NC_GLOBAL,institution,,Test Org
+variable,time,,double,
+attribute,time,actual_range,,"2020-01-01T00:00:00Z,2025-01-01T00:00:00Z"
+variable,latitude,,double,
+variable,longitude,,double,
+variable,my_fake_var,,double,
+attribute,my_fake_var,standard_name,,some_completely_fake_variable_xyz
+variable,station_id,,String,
+attribute,station_id,cf_role,,timeseries_id
+"""
+
+# Info CSV for a dataset with cde_ingest=False
+ERDDAP_INFO_INGEST_FALSE_CSV = """\
+Row Type,Variable Name,Attribute Name,Data Type,Value
+attribute,NC_GLOBAL,cdm_data_type,,TimeSeries
+attribute,NC_GLOBAL,title,,Excluded Dataset
+attribute,NC_GLOBAL,institution,,Test Org
+attribute,NC_GLOBAL,cde_ingest,,False
+variable,time,,double,
+variable,latitude,,double,
+variable,longitude,,double,
+variable,temperature,,double,
+attribute,temperature,standard_name,,sea_water_temperature
+variable,station_id,,String,
+attribute,station_id,cf_role,,timeseries_id
+"""
+
+# Info CSV for a dataset with both depth AND altitude (should be excluded)
+ERDDAP_INFO_DEPTH_AND_ALTITUDE_CSV = """\
+Row Type,Variable Name,Attribute Name,Data Type,Value
+attribute,NC_GLOBAL,cdm_data_type,,TimeSeries
+attribute,NC_GLOBAL,title,,Depth+Altitude Dataset
+attribute,NC_GLOBAL,institution,,Test Org
+variable,time,,double,
+variable,latitude,,double,
+variable,longitude,,double,
+variable,depth,,double,
+variable,altitude,,double,
+variable,temperature,,double,
+attribute,temperature,standard_name,,sea_water_temperature
+variable,station_id,,String,
+attribute,station_id,cf_role,,timeseries_id
+"""
+
+# tabledap profile IDs (distinct) — skiprows=[1] skips the units row.
+ERDDAP_PROFILE_IDS_CSV = """\
+station_id,latitude,longitude
+(String),(degrees_north),(degrees_east)
+STATION_001,48.5,-125.0
+"""
+
+# 2-station variant for multi-profile tests
+ERDDAP_PROFILE_IDS_TWO_CSV = """\
+station_id,latitude,longitude
+(String),(degrees_north),(degrees_east)
+STATION_001,48.5,-125.0
+STATION_002,49.0,-124.5
+"""
+
+# orderByMinMax for time, 2 stations — even rows = max, odd rows = min.
+ERDDAP_TIME_MINMAX_CSV = """\
+station_id,time
+(String),(UTC)
+STATION_001,2023-12-31T00:00:00Z
+STATION_001,2020-01-01T00:00:00Z
+STATION_002,2022-12-31T00:00:00Z
+STATION_002,2021-01-01T00:00:00Z
+"""
+
+# orderByMinMax for depth, 2 stations
+ERDDAP_DEPTH_MINMAX_CSV = """\
+station_id,depth
+(String),(m)
+STATION_001,200.5
+STATION_001,0.5
+STATION_002,150.0
+STATION_002,1.0
+"""
+
+# orderByCount for (depth, station_id, time) grouped by station_id
+ERDDAP_COUNT_CSV = """\
+depth,station_id,time
+(count),(count),(count)
+1000,STATION_001,1000
+500,STATION_002,500
+"""
+
+
+# ---------------------------------------------------------------------------
+# CKAN response fixture
+# ---------------------------------------------------------------------------
+
+CKAN_PACKAGE_SEARCH_RESPONSE = {
+    "result": {
+        "count": 1,
+        "results": [
+            {
+                "id": "ckan-uuid-001",
+                "title_translated": {
+                    "en": "Test Dataset English Title",
+                    "fr": "Test Dataset French Title",
+                },
+                "notes_translated": {
+                    "en": "English summary.",
+                    "fr": "French summary.",
+                },
+                "cited-responsible-party": [
+                    {"organisation-name": "CIOOS Test Organization"}
+                ],
+                "resources": [
+                    {
+                        "url": (
+                            "https://test.erddap.com/erddap/tabledap/"
+                            "test_timeseries_001.html"
+                        ),
+                        "format": "ERDDAP tabledap",
+                    }
+                ],
+            }
+        ],
+    }
+}
+
+# Empty CKAN response for second page (stops pagination)
+CKAN_EMPTY_RESPONSE = {"result": {"count": 1, "results": []}}
+
+
+# ---------------------------------------------------------------------------
+# MockResponse — simulates a requests.Response object
+# ---------------------------------------------------------------------------
+
+class MockResponse:
+    """Minimal requests.Response substitute for HTTP mocking."""
+
+    def __init__(self, text="", status_code=200, url=None):
+        self.text = text
+        self.content = text.encode("utf-8") if isinstance(text, str) else text
+        self.status_code = status_code
+        self.url = url or ERDDAP_URL + "/mocked"
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            import requests
+            raise requests.exceptions.HTTPError(response=self)
+
+
+# ---------------------------------------------------------------------------
+# URL routing helper — maps an ERDDAP request URL to a fixture CSV string
+# ---------------------------------------------------------------------------
+
+def _route_erddap_url(url: str) -> str:
+    """Return the appropriate fixture CSV text for a given ERDDAP request URL."""
+    from urllib.parse import unquote
+    decoded = unquote(url)
+
+    if "allDatasets" in decoded:
+        return ERDDAP_ALL_DATASETS_CSV
+    if "/info/" in decoded:
+        return ERDDAP_INFO_CSV
+    if "distinct()" in decoded:
+        return ERDDAP_PROFILE_IDS_CSV
+    if "orderByMinMax" in decoded:
+        # distinguish time from depth by what appears before orderByMinMax
+        pre = decoded.split("orderByMinMax")[0]
+        if ",depth" in pre or "depth," in pre:
+            return ERDDAP_DEPTH_MINMAX_CSV
+        return ERDDAP_TIME_MINMAX_CSV
+    if "orderByCount" in decoded:
+        return ERDDAP_COUNT_CSV
+    return ""
+
+
+def make_mock_session_get(url, **kwargs):
+    """side_effect for requests.Session.get that routes to fixture data."""
+    text = _route_erddap_url(url)
+    return MockResponse(text=text, url=url)
+
+
+# ---------------------------------------------------------------------------
+# Helpers to build DataFrames directly (bypassing HTTP) for unit tests
+# ---------------------------------------------------------------------------
+
+def build_info_df(csv_text: str = ERDDAP_INFO_CSV) -> pd.DataFrame:
+    """Parse an ERDDAP info CSV string into a DataFrame as Dataset.get_metadata() would."""
+    return pd.read_csv(StringIO(csv_text)).fillna("")
+
+
+def build_variables_df(csv_text: str = ERDDAP_INFO_CSV) -> pd.DataFrame:
+    """
+    Build the df_variables DataFrame exactly as Dataset.get_metadata() does,
+    so unit tests for ComplianceChecker / profiles can use a realistic object.
+    """
+    df = build_info_df(csv_text)
+    considered_attributes = ["cf_role", "standard_name", "actual_range"]
+
+    data_types = df.query(
+        '(`Variable Name`!="NC_GLOBAL" and `Attribute Name`=="")'
+    )[["Variable Name", "Data Type"]].set_index("Variable Name")
+
+    attr_df = df.query("`Attribute Name` in @considered_attributes")[
+        ["Variable Name", "Attribute Name", "Value"]
+    ]
+    if not attr_df.empty:
+        attributes = attr_df.pivot(
+            index="Variable Name", columns="Attribute Name", values="Value"
+        ).fillna("")
+    else:
+        attributes = pd.DataFrame(index=data_types.index)
+
+    df_variables = data_types.join(attributes).fillna("")
+    df_variables = df_variables.reset_index().rename(
+        columns={"Variable Name": "name", "Data Type": "type"}
+    )
+    df_variables["erddap_url"] = ERDDAP_URL
+    df_variables["dataset_id"] = DATASET_ID
+    if "standard_name" not in df_variables:
+        df_variables["standard_name"] = ""
+    if "cf_role" not in df_variables:
+        df_variables["cf_role"] = ""
+    if "actual_range" not in df_variables:
+        df_variables["actual_range"] = ""
+    df_variables.set_index("name", drop=False, inplace=True)
+    return df_variables
+
+
+def build_mock_dataset(
+    info_csv: str = ERDDAP_INFO_CSV,
+    cdm_data_type: str = "TimeSeries",
+) -> MagicMock:
+    """
+    Build a realistic MagicMock Dataset with all attributes that
+    CDEComplianceChecker and get_profiles depend on.
+    """
+    df_variables = build_variables_df(info_csv)
+    variables_list = df_variables["name"].tolist()
+
+    mock = MagicMock()
+    mock.id = DATASET_ID
+    mock.erddap_url = ERDDAP_URL
+    mock.cdm_data_type = cdm_data_type
+    mock.df_variables = df_variables
+    mock.variables_list = variables_list
+    mock.logger = logging.getLogger("test.mock_dataset")
+
+    # Globals parsed from NC_GLOBAL attributes
+    info_df = build_info_df(info_csv)
+    global_rows = info_df.query('`Variable Name`=="NC_GLOBAL"')[
+        ["Attribute Name", "Value"]
+    ].set_index("Attribute Name")
+    mock.globals = global_rows["Value"].to_dict()
+
+    # EOVs — use the real utility to derive them
+    from cde_harvester.utils import cde_eov_to_standard_name, intersection
+    eovs = []
+    dataset_standard_names = df_variables["standard_name"].tolist()
+    for eov, standard_names in cde_eov_to_standard_name.items():
+        if intersection(dataset_standard_names, standard_names):
+            eovs.append(eov)
+    mock.eovs = eovs
+
+    mock.organizations = [mock.globals.get("institution", "")]
+    mock.platform = "unknown"
+
+    # profile_variables / profile_variable_list from cf_role column
+    pv = (
+        df_variables.query('cf_role != ""')
+        .set_index("cf_role")["name"]
+        .to_dict()
+    )
+    mock.profile_variables = pv
+    mock.profile_variable_list = sorted(list(pv.values()))
+
+    # timeseries_id / profile_id / trajectory_id
+    mock.timeseries_id_variable = pv.get("timeseries_id")
+    mock.profile_id_variable = pv.get("profile_id")
+    mock.trajectory_id_variable = pv.get("trajectory_id")
+    mock.first_eov_column = "temperature"
+
+    # profile_ids DataFrame (single station for unit tests)
+    profile_ids_df = pd.read_csv(
+        StringIO(ERDDAP_PROFILE_IDS_CSV), skiprows=[1]
+    )
+    profile_ids_df["latlon"] = (
+        profile_ids_df["latitude"].astype(str)
+        + ","
+        + profile_ids_df["longitude"].astype(str)
+    )
+    profile_ids_df = profile_ids_df.drop_duplicates(mock.profile_variable_list)
+    del profile_ids_df["latlon"]
+    mock.profile_ids = profile_ids_df
+
+    # get_profile_ids() returns the same DataFrame
+    mock.get_profile_ids.return_value = profile_ids_df.copy()
+
+    # get_max_min() — return per-variable DataFrames
+    def _get_max_min(vars_list):
+        last_var = vars_list[-1]
+        index_vars = vars_list[:-1]
+        if last_var == "time":
+            data = {
+                "station_id": ["STATION_001"],
+                "time_min": ["2020-01-01T00:00:00Z"],
+                "time_max": ["2023-12-31T00:00:00Z"],
+            }
+        else:
+            data = {
+                "station_id": ["STATION_001"],
+                f"{last_var}_min": [0.5],
+                f"{last_var}_max": [200.5],
+            }
+        df = pd.DataFrame(data).set_index(index_vars)
+        return df
+
+    mock.get_max_min.side_effect = _get_max_min
+
+    # get_count() — return counts indexed by profile variable
+    count_df = pd.DataFrame(
+        {"depth": [1000], "station_id": ["STATION_001"], "time": [1000]}
+    )
+    mock.get_count.return_value = count_df
+
+    # get_df() — DataFrame row for the datasets CSV
+    mock.get_df.return_value = pd.DataFrame(
+        {
+            "title": ["Test Temperature Dataset"],
+            "erddap_url": [ERDDAP_URL],
+            "dataset_id": [DATASET_ID],
+            "cdm_data_type": [cdm_data_type],
+            "platform": ["unknown"],
+            "eovs": [mock.eovs],
+            "organizations": [mock.organizations],
+            "n_profiles": [1],
+            "profile_variables": [mock.profile_variable_list],
+            "timeseries_id_variable": [mock.timeseries_id_variable],
+            "profile_id_variable": [mock.profile_id_variable],
+            "trajectory_id_variable": [mock.trajectory_id_variable],
+            "num_columns": [len(df_variables)],
+            "first_eov_column": ["temperature"],
+        }
+    )
+    return mock
+
+
+# ---------------------------------------------------------------------------
+# Pytest fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def mock_dataset():
+    """Realistic MagicMock Dataset for compliance and profile unit tests."""
+    return build_mock_dataset()
+
+
+@pytest.fixture
+def mock_erddap_server(mocker):
+    """
+    Mocked ERDDAP server object. Provides the interface that Dataset.__init__
+    calls (url, domain, erddap_csv_to_df) without making any real HTTP calls.
+    """
+    server = MagicMock()
+    server.url = ERDDAP_URL
+    server.domain = DOMAIN
+
+    def _erddap_csv_to_df(url, skiprows=None, dataset=None):
+        if "/info/" in url:
+            return pd.read_csv(StringIO(ERDDAP_INFO_CSV)).fillna("")
+        return pd.DataFrame()
+
+    server.erddap_csv_to_df.side_effect = _erddap_csv_to_df
+    return server
+
+
+@pytest.fixture
+def sample_datasets_df():
+    """A minimal datasets DataFrame as produced by harvest_erddap."""
+    return pd.DataFrame(
+        {
+            "title": ["Test Temperature Dataset"],
+            "erddap_url": [ERDDAP_URL],
+            "dataset_id": [DATASET_ID],
+            "cdm_data_type": ["TimeSeries"],
+            "platform": ["unknown"],
+            "eovs": [["seaSurfaceTemperature"]],
+            "organizations": [["Test Institution"]],
+            "n_profiles": [1],
+            "profile_variables": [["station_id"]],
+            "timeseries_id_variable": ["station_id"],
+            "profile_id_variable": [None],
+            "trajectory_id_variable": [None],
+            "num_columns": [6],
+            "first_eov_column": ["temperature"],
+        }
+    )
+
+
+@pytest.fixture
+def sample_profiles_df():
+    """A minimal profiles DataFrame as produced by get_profiles."""
+    return pd.DataFrame(
+        {
+            "timeseries_id": ["STATION_001"],
+            "profile_id": [""],
+            "latitude": [48.5],
+            "longitude": [-125.0],
+            "time_min": [pd.Timestamp("2020-01-01", tz="UTC")],
+            "time_max": [pd.Timestamp("2023-12-31", tz="UTC")],
+            "depth_min": [0.5],
+            "depth_max": [200.5],
+            "n_records": [1000.0],
+            "records_per_day": [0.7519],
+            "dataset_id": [DATASET_ID],
+            "erddap_url": [ERDDAP_URL],
+        }
+    )
+
+
+@pytest.fixture
+def sample_variables_df():
+    """Variable-level DataFrame as produced during harvest."""
+    return build_variables_df()
+
+
+@pytest.fixture
+def sample_skipped_df():
+    """Skipped datasets DataFrame."""
+    return pd.DataFrame(
+        {
+            "erddap_url": [DOMAIN],
+            "dataset_id": ["skipped_001"],
+            "reason_code": ["NO_SUPPORTED_VARIABLES"],
+        }
+    )

--- a/tests/integration/test_full_pipeline.py
+++ b/tests/integration/test_full_pipeline.py
@@ -1,0 +1,263 @@
+"""
+Integration test: full harvester pipeline with mocked external I/O.
+
+Steps covered (mirrors the real nightly run):
+  1. ERDDAP HTTP calls  → mocked via requests.Session.get
+  2. CKAN HTTP calls    → mocked via requests.get
+  3. harvest_erddap()   → runs with real Dataset/ComplianceChecker/profiles logic
+  4. CSV output         → written to tmp_path via the real __main__.main()
+  5. DB load            → SQLAlchemy engine mocked; correct SQL calls asserted
+
+The test does NOT contact any live services.  It exercises the complete
+data-flow transformation described in docs/data_flow.md.
+"""
+
+import ast
+import os
+from io import StringIO
+from unittest.mock import MagicMock, patch
+from urllib.parse import unquote
+
+import pandas as pd
+import pytest
+
+from conftest import (
+    CKAN_EMPTY_RESPONSE,
+    CKAN_PACKAGE_SEARCH_RESPONSE,
+    DATASET_ID,
+    ERDDAP_ALL_DATASETS_CSV,
+    ERDDAP_COUNT_CSV,
+    ERDDAP_DEPTH_MINMAX_CSV,
+    ERDDAP_INFO_CSV,
+    ERDDAP_PROFILE_IDS_CSV,
+    ERDDAP_TIME_MINMAX_CSV,
+    ERDDAP_URL,
+    MockResponse,
+    _route_erddap_url,
+)
+
+
+# ---------------------------------------------------------------------------
+# Session-level mock for all ERDDAP HTTP calls
+# ---------------------------------------------------------------------------
+
+def _erddap_session_get(url, **kwargs):
+    """Route every ERDDAP request to the right fixture CSV."""
+    text = _route_erddap_url(url)
+    return MockResponse(text=text, url=url)
+
+
+# ---------------------------------------------------------------------------
+# Step 1 + 2 + 3: Harvest phase (ERDDAP + CKAN → DataFrames)
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module")
+def harvest_result(tmp_path_factory):
+    """
+    Run the real harvest_erddap() against a fully-mocked ERDDAP server.
+    Returns (profiles_df, datasets_df, variables_df, skipped_df).
+    """
+    tmp = tmp_path_factory.mktemp("harvest_phase")
+
+    ckan_page1 = MagicMock()
+    ckan_page1.json.return_value = CKAN_PACKAGE_SEARCH_RESPONSE
+    ckan_page2 = MagicMock()
+    ckan_page2.json.return_value = CKAN_EMPTY_RESPONSE
+
+    with (
+        patch("cde_harvester.ERDDAP.requests.Session") as mock_session_cls,
+        patch(
+            "cde_harvester.ckan.create_ckan_erddap_link.requests.get",
+            side_effect=[ckan_page1, ckan_page2],
+        ),
+    ):
+        mock_session = MagicMock()
+        mock_session.get.side_effect = _erddap_session_get
+        mock_session_cls.return_value = mock_session
+
+        from cde_harvester.harvest_erddap import harvest_erddap
+
+        result = []
+        harvest_erddap(ERDDAP_URL, result, limit_dataset_ids=[DATASET_ID])
+
+    assert result, "harvest_erddap produced no output"
+    profiles, datasets, variables, skipped = result[0]
+    return profiles, datasets, variables, skipped
+
+
+# ---------------------------------------------------------------------------
+# Step 3 tests: harvest output content
+# ---------------------------------------------------------------------------
+
+class TestHarvestOutput:
+    def test_compliant_dataset_is_harvested(self, harvest_result):
+        _, datasets, _, _ = harvest_result
+        assert DATASET_ID in datasets["dataset_id"].values
+
+    def test_at_least_one_profile_extracted(self, harvest_result):
+        profiles, _, _, _ = harvest_result
+        assert len(profiles) >= 1
+
+    def test_profiles_have_required_columns(self, harvest_result):
+        profiles, _, _, _ = harvest_result
+        required = [
+            "latitude", "longitude", "time_min", "time_max",
+            "depth_min", "depth_max", "n_records", "dataset_id", "erddap_url",
+        ]
+        for col in required:
+            assert col in profiles.columns, f"Profiles missing column: {col}"
+
+    def test_dataset_has_eovs(self, harvest_result):
+        _, datasets, _, _ = harvest_result
+        row = datasets[datasets["dataset_id"] == DATASET_ID].iloc[0]
+        assert len(row["eovs"]) > 0
+
+    def test_unsupported_dataset_is_skipped(self, harvest_result):
+        """
+        allDatasets CSV includes 'test_unsupported_001' (Point type).
+        It should NOT appear in datasets (filtered before get_dataset is called).
+        """
+        _, datasets, _, skipped = harvest_result
+        assert "test_unsupported_001" not in datasets["dataset_id"].values
+
+    def test_variables_dataframe_populated(self, harvest_result):
+        _, _, variables, _ = harvest_result
+        assert not variables.empty
+        assert "standard_name" in variables.columns
+
+
+# ---------------------------------------------------------------------------
+# Step 4: CSV writing phase
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module")
+def written_csv_folder(tmp_path_factory, harvest_result):
+    """
+    Run the harvester __main__.main() (CKAN + merge + write CSVs) using the
+    harvest_result DataFrames, capturing the folder it writes to.
+    """
+    profiles, datasets, variables, skipped = harvest_result
+    tmp = tmp_path_factory.mktemp("csv_phase")
+    folder = str(tmp)
+
+    ckan_page1 = MagicMock()
+    ckan_page1.json.return_value = CKAN_PACKAGE_SEARCH_RESPONSE
+    ckan_page2 = MagicMock()
+    ckan_page2.json.return_value = CKAN_EMPTY_RESPONSE
+
+    with (
+        patch("cde_harvester.ERDDAP.requests.Session") as mock_session_cls,
+        patch(
+            "cde_harvester.ckan.create_ckan_erddap_link.requests.get",
+            side_effect=[ckan_page1, ckan_page2],
+        ),
+    ):
+        mock_session = MagicMock()
+        mock_session.get.side_effect = _erddap_session_get
+        mock_session_cls.return_value = mock_session
+
+        from cde_harvester.__main__ import main as harvester_main
+
+        harvester_main(
+            erddap_urls=ERDDAP_URL,
+            cache_requests=False,
+            folder=folder,
+            dataset_ids=DATASET_ID,
+            max_workers=1,
+        )
+
+    return folder
+
+
+class TestCsvFilesWritten:
+    def test_datasets_csv_exists(self, written_csv_folder):
+        assert os.path.exists(os.path.join(written_csv_folder, "datasets.csv"))
+
+    def test_profiles_csv_exists(self, written_csv_folder):
+        assert os.path.exists(os.path.join(written_csv_folder, "profiles.csv"))
+
+    def test_skipped_csv_exists(self, written_csv_folder):
+        assert os.path.exists(os.path.join(written_csv_folder, "skipped.csv"))
+
+    def test_datasets_csv_readable(self, written_csv_folder):
+        df = pd.read_csv(os.path.join(written_csv_folder, "datasets.csv"))
+        assert not df.empty
+
+    def test_profiles_csv_readable(self, written_csv_folder):
+        df = pd.read_csv(os.path.join(written_csv_folder, "profiles.csv"))
+        assert not df.empty
+
+    def test_datasets_csv_array_columns_parse_correctly(self, written_csv_folder):
+        df = pd.read_csv(os.path.join(written_csv_folder, "datasets.csv"))
+        for col in ["eovs", "organizations", "profile_variables"]:
+            parsed = df[col].apply(ast.literal_eval)
+            assert all(isinstance(v, list) for v in parsed)
+
+    def test_ckan_title_merged_into_datasets(self, written_csv_folder):
+        df = pd.read_csv(os.path.join(written_csv_folder, "datasets.csv"))
+        row = df[df["dataset_id"] == DATASET_ID].iloc[0]
+        assert "Test Dataset" in str(row["title"])
+
+    def test_french_title_present(self, written_csv_folder):
+        df = pd.read_csv(os.path.join(written_csv_folder, "datasets.csv"))
+        row = df[df["dataset_id"] == DATASET_ID].iloc[0]
+        # title_fr must be non-null (CKAN provided it)
+        assert pd.notna(row.get("title_fr"))
+
+
+# ---------------------------------------------------------------------------
+# Step 5: DB load phase
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module")
+def db_load_calls(written_csv_folder):
+    """
+    Run db-loader main() against the written CSVs with a mocked SQLAlchemy
+    engine.  Returns the list of SQL strings passed to text().
+    """
+    engine = MagicMock()
+    conn = MagicMock()
+    engine.begin.return_value.__enter__.return_value = conn
+    engine.begin.return_value.__exit__.return_value = False
+
+    sql_calls = []
+
+    with (
+        patch("cde_db_loader.__main__.create_engine", return_value=engine),
+        patch("cde_db_loader.__main__.load_dotenv"),
+        patch(
+            "cde_db_loader.__main__.text",
+            side_effect=lambda s: sql_calls.append(s) or s,
+        ),
+        patch("pandas.DataFrame.to_sql"),
+        patch.dict(
+            os.environ,
+            {
+                "DB_USER": "u", "DB_PASSWORD": "p",
+                "DB_HOST_EXTERNAL": "localhost",
+                "DB_PORT": "5432", "DB_NAME": "testdb",
+            },
+        ),
+    ):
+        from cde_db_loader.__main__ import main as db_main
+
+        db_main(written_csv_folder, incremental=False)
+
+    return sql_calls
+
+
+class TestDbLoadPhase:
+    def test_drop_constraints_called(self, db_load_calls):
+        assert any("drop_constraints" in c for c in db_load_calls)
+
+    def test_remove_all_data_called(self, db_load_calls):
+        assert any("remove_all_data" in c for c in db_load_calls)
+
+    def test_profile_process_called(self, db_load_calls):
+        assert any("profile_process" in c for c in db_load_calls)
+
+    def test_create_hexes_called(self, db_load_calls):
+        assert any("create_hexes" in c for c in db_load_calls)
+
+    def test_set_constraints_called(self, db_load_calls):
+        assert any("set_constraints" in c for c in db_load_calls)

--- a/tests/pyproject.toml
+++ b/tests/pyproject.toml
@@ -1,0 +1,21 @@
+[project]
+name = "cioos-harvester-tests"
+version = "0.1.0"
+description = "Validation test suite for the CIOOS data harvester pipeline"
+readme = "README.md"
+requires-python = ">=3.10,<3.11"
+dependencies = [
+    "harvester",
+    "db-loader",
+    "pytest>=8.2",
+    "pytest-mock>=3.14",
+    "pytest-cov>=5.0",
+]
+
+[tool.uv.sources]
+harvester = { path = "../harvester", editable = true }
+db-loader = { path = "../db-loader", editable = true }
+
+[tool.pytest.ini_options]
+testpaths = ["unit", "integration"]
+addopts = "-v --tb=short"

--- a/tests/unit/test_ckan.py
+++ b/tests/unit/test_ckan.py
@@ -1,0 +1,120 @@
+"""
+Unit tests for cde_harvester.ckan.create_ckan_erddap_link.
+
+All outbound CKAN HTTP calls are intercepted with pytest-mock so the tests run
+offline and deterministically.
+"""
+
+import json
+
+import pandas as pd
+import pytest
+
+from conftest import (
+    CKAN_EMPTY_RESPONSE,
+    CKAN_PACKAGE_SEARCH_RESPONSE,
+    DATASET_ID,
+    ERDDAP_URL,
+)
+from cde_harvester.ckan.create_ckan_erddap_link import (
+    get_ckan_records,
+    split_erddap_url,
+    unescape_ascii,
+    unescape_ascii_list,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_ckan_get(mocker, pages):
+    """
+    Patch requests.get inside the ckan module with a sequence of page responses.
+    Each call to list_ckan_records_with_erddap_urls paginates until results empty.
+    """
+    responses = []
+    for page in pages:
+        mock_resp = mocker.MagicMock()
+        mock_resp.json.return_value = page
+        responses.append(mock_resp)
+
+    mocker.patch(
+        "cde_harvester.ckan.create_ckan_erddap_link.requests.get",
+        side_effect=responses,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests: URL parsing
+# ---------------------------------------------------------------------------
+
+class TestSplitErddapUrl:
+    def test_standard_tabledap_url(self):
+        host, ds_id = split_erddap_url(
+            "https://data.cioospacific.ca/erddap/tabledap/IOS_BOT_Profiles.html"
+        )
+        assert host == "https://data.cioospacific.ca"
+        assert ds_id == "IOS_BOT_Profiles"
+
+    def test_url_with_language_prefix(self):
+        host, ds_id = split_erddap_url(
+            "https://cnodc.example.ca/erddap/fr/tabledap/cnodc_dataset.html"
+        )
+        assert ds_id == "cnodc_dataset"
+
+    def test_invalid_url_raises_value_error(self):
+        with pytest.raises(ValueError, match="Invalid URL format"):
+            split_erddap_url("https://example.com/not/erddap")
+
+
+# ---------------------------------------------------------------------------
+# Tests: ASCII unescaping
+# ---------------------------------------------------------------------------
+
+class TestUnescapeAscii:
+    def test_plain_string_unchanged(self):
+        assert unescape_ascii("hello") == "hello"
+
+    def test_non_ascii_fallback_returns_input(self):
+        # Passing a non-decodable sequence should return the original value
+        result = unescape_ascii(b"\xff\xfe")
+        assert result == b"\xff\xfe"
+
+    def test_list_unescaping(self):
+        result = unescape_ascii_list(["hello", "world"])
+        assert result == ["hello", "world"]
+
+
+# ---------------------------------------------------------------------------
+# Tests: get_ckan_records
+# ---------------------------------------------------------------------------
+
+class TestGetCkanRecords:
+    def test_returns_dataframe(self, mocker):
+        _make_ckan_get(mocker, [CKAN_PACKAGE_SEARCH_RESPONSE, CKAN_EMPTY_RESPONSE])
+        df = get_ckan_records([DATASET_ID])
+        assert isinstance(df, pd.DataFrame)
+
+    def test_dataframe_has_expected_columns(self, mocker):
+        _make_ckan_get(mocker, [CKAN_PACKAGE_SEARCH_RESPONSE, CKAN_EMPTY_RESPONSE])
+        df = get_ckan_records([DATASET_ID])
+        for col in ["erddap_url", "dataset_id", "ckan_id", "ckan_organizations", "ckan_title", "title_fr"]:
+            assert col in df.columns
+
+    def test_dataset_id_matched(self, mocker):
+        _make_ckan_get(mocker, [CKAN_PACKAGE_SEARCH_RESPONSE, CKAN_EMPTY_RESPONSE])
+        df = get_ckan_records([DATASET_ID])
+        assert DATASET_ID in df["dataset_id"].values
+
+    def test_title_extracted(self, mocker):
+        _make_ckan_get(mocker, [CKAN_PACKAGE_SEARCH_RESPONSE, CKAN_EMPTY_RESPONSE])
+        df = get_ckan_records([DATASET_ID])
+        row = df[df["dataset_id"] == DATASET_ID].iloc[0]
+        assert row["ckan_title"] == "Test Dataset English Title"
+        assert row["title_fr"] == "Test Dataset French Title"
+
+    def test_no_matching_dataset_returns_empty(self, mocker):
+        _make_ckan_get(mocker, [CKAN_PACKAGE_SEARCH_RESPONSE, CKAN_EMPTY_RESPONSE])
+        df = get_ckan_records(["non_existent_dataset"])
+        assert df.empty

--- a/tests/unit/test_compliance_checker.py
+++ b/tests/unit/test_compliance_checker.py
@@ -1,0 +1,121 @@
+"""
+Unit tests for cde_harvester.CDEComplianceChecker.
+
+Each test builds a mock Dataset, sets specific attributes, and verifies
+whether the compliance checker passes or rejects it with the right code.
+"""
+
+import pytest
+
+from conftest import (
+    ERDDAP_INFO_CSV,
+    ERDDAP_INFO_DEPTH_AND_ALTITUDE_CSV,
+    ERDDAP_INFO_INGEST_FALSE_CSV,
+    ERDDAP_INFO_NO_EOVS_CSV,
+    build_mock_dataset,
+)
+from cde_harvester.CDEComplianceChecker import CDEComplianceChecker
+from cde_harvester.harvest_errors import (
+    DEPTH_AND_ALTITUDE,
+    INGEST_FLAG_FALSE,
+    MISSING_REQUIRED_VARS,
+    NO_SUPPORTED_VARIABLES,
+)
+
+
+def _checker(info_csv=ERDDAP_INFO_CSV, **overrides):
+    """Build a CDEComplianceChecker from a mock dataset, with optional overrides."""
+    dataset = build_mock_dataset(info_csv)
+    for attr, value in overrides.items():
+        setattr(dataset, attr, value)
+    return CDEComplianceChecker(dataset)
+
+
+class TestPassesAllChecks:
+    def test_valid_timeseries_dataset_passes(self):
+        checker = _checker()
+        assert checker.passes_all_checks() is True
+
+    def test_failure_reason_code_empty_on_pass(self):
+        checker = _checker()
+        checker.passes_all_checks()
+        assert checker.failure_reason_code == ""
+
+
+class TestRequiredVariables:
+    def test_missing_time_fails(self):
+        checker = _checker()
+        # Remove 'time' from variables_list
+        checker.dataset.variables_list = [
+            v for v in checker.dataset.variables_list if v != "time"
+        ]
+        assert checker.check_required_variables() is False
+        assert checker.failure_reason_code == MISSING_REQUIRED_VARS
+
+    def test_missing_latitude_fails(self):
+        checker = _checker()
+        checker.dataset.variables_list = [
+            v for v in checker.dataset.variables_list if v != "latitude"
+        ]
+        assert checker.check_required_variables() is False
+        assert checker.failure_reason_code == MISSING_REQUIRED_VARS
+
+    def test_missing_longitude_fails(self):
+        checker = _checker()
+        checker.dataset.variables_list = [
+            v for v in checker.dataset.variables_list if v != "longitude"
+        ]
+        assert checker.check_required_variables() is False
+        assert checker.failure_reason_code == MISSING_REQUIRED_VARS
+
+    def test_all_required_present_passes(self):
+        checker = _checker()
+        assert checker.check_required_variables() is True
+
+
+class TestSupportedCFName:
+    def test_dataset_with_sea_water_temperature_passes(self):
+        checker = _checker()
+        assert checker.check_supported_cf_name() is True
+
+    def test_dataset_with_no_supported_standard_names_fails(self):
+        checker = _checker(ERDDAP_INFO_NO_EOVS_CSV)
+        assert checker.check_supported_cf_name() is False
+        assert checker.failure_reason_code == NO_SUPPORTED_VARIABLES
+
+
+class TestIngestFlag:
+    def test_no_cde_ingest_flag_passes(self):
+        checker = _checker()
+        # globals has no cde_ingest key
+        assert checker.cde_ingest_flag() is True
+
+    def test_cde_ingest_false_fails(self):
+        checker = _checker(ERDDAP_INFO_INGEST_FALSE_CSV)
+        assert checker.cde_ingest_flag() is False
+        assert checker.failure_reason_code == INGEST_FLAG_FALSE
+
+    def test_cde_ingest_true_passes(self):
+        checker = _checker()
+        checker.dataset.globals["cde_ingest"] = "True"
+        assert checker.cde_ingest_flag() is True
+
+
+class TestDepthAndAltitude:
+    def test_only_depth_passes(self):
+        checker = _checker()
+        assert "depth" in checker.dataset.variables_list
+        assert "altitude" not in checker.dataset.variables_list
+        assert checker.check_only_one_depth() is True
+
+    def test_depth_and_altitude_together_fails(self):
+        checker = _checker(ERDDAP_INFO_DEPTH_AND_ALTITUDE_CSV)
+        assert checker.check_only_one_depth() is False
+        assert checker.failure_reason_code == DEPTH_AND_ALTITUDE
+
+    def test_only_altitude_passes(self):
+        checker = _checker()
+        checker.dataset.variables_list = [
+            v for v in checker.dataset.variables_list if v != "depth"
+        ] + ["altitude"]
+        assert checker.check_only_one_depth() is True

--- a/tests/unit/test_csv_generation.py
+++ b/tests/unit/test_csv_generation.py
@@ -1,0 +1,128 @@
+"""
+Unit tests for CSV file generation and structural validation.
+
+Validates that:
+- The output CSVs written by the harvester have the correct columns and types
+- No required fields are empty after harvest
+- Duplicate removal works correctly
+- The DB loader can read back the written CSVs (column contract is intact)
+"""
+
+import ast
+
+import pandas as pd
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Expected column contracts (must match what db-loader reads)
+# ---------------------------------------------------------------------------
+
+REQUIRED_DATASETS_COLS = [
+    "title", "erddap_url", "dataset_id", "cdm_data_type",
+    "platform", "eovs", "organizations", "n_profiles",
+    "profile_variables", "timeseries_id_variable",
+]
+
+REQUIRED_PROFILES_COLS = [
+    "dataset_id", "erddap_url", "latitude", "longitude",
+    "time_min", "time_max", "depth_min", "depth_max",
+    "n_records", "records_per_day",
+]
+
+REQUIRED_SKIPPED_COLS = ["erddap_url", "dataset_id", "reason_code"]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _write_and_read_csv(df: pd.DataFrame, tmp_path, filename: str) -> pd.DataFrame:
+    """Write a DataFrame to CSV and read it back as the db-loader would."""
+    path = tmp_path / filename
+    df.to_csv(path, index=False)
+    return pd.read_csv(path)
+
+
+# ---------------------------------------------------------------------------
+# Tests: datasets.csv
+# ---------------------------------------------------------------------------
+
+class TestDatasetsCsvStructure:
+    def test_all_required_columns_present(self, sample_datasets_df):
+        for col in REQUIRED_DATASETS_COLS:
+            assert col in sample_datasets_df.columns, f"Missing column: {col}"
+
+    def test_dataset_id_is_non_empty(self, sample_datasets_df):
+        assert sample_datasets_df["dataset_id"].notna().all()
+        assert (sample_datasets_df["dataset_id"] != "").all()
+
+    def test_eovs_is_list_after_roundtrip(self, sample_datasets_df, tmp_path):
+        df = _write_and_read_csv(sample_datasets_df, tmp_path, "datasets.csv")
+        # db-loader uses ast.literal_eval to parse back the array columns
+        eovs_parsed = df["eovs"].apply(ast.literal_eval)
+        assert all(isinstance(v, list) for v in eovs_parsed)
+
+    def test_organizations_is_list_after_roundtrip(self, sample_datasets_df, tmp_path):
+        df = _write_and_read_csv(sample_datasets_df, tmp_path, "datasets.csv")
+        orgs_parsed = df["organizations"].apply(ast.literal_eval)
+        assert all(isinstance(v, list) for v in orgs_parsed)
+
+    def test_profile_variables_is_list_after_roundtrip(self, sample_datasets_df, tmp_path):
+        df = _write_and_read_csv(sample_datasets_df, tmp_path, "datasets.csv")
+        pv_parsed = df["profile_variables"].apply(ast.literal_eval)
+        assert all(isinstance(v, list) for v in pv_parsed)
+
+    def test_no_duplicate_dataset_ids_after_write(self, sample_datasets_df, tmp_path):
+        # Simulate the drop_duplicates call in __main__.py
+        deduped = sample_datasets_df.drop_duplicates(["erddap_url", "dataset_id"])
+        df = _write_and_read_csv(deduped, tmp_path, "datasets.csv")
+        assert df.duplicated(["erddap_url", "dataset_id"]).sum() == 0
+
+
+# ---------------------------------------------------------------------------
+# Tests: profiles.csv
+# ---------------------------------------------------------------------------
+
+class TestProfilesCsvStructure:
+    def test_all_required_columns_present(self, sample_profiles_df):
+        for col in REQUIRED_PROFILES_COLS:
+            assert col in sample_profiles_df.columns, f"Missing column: {col}"
+
+    def test_latitude_within_bounds(self, sample_profiles_df):
+        assert (sample_profiles_df["latitude"] > -90).all()
+        assert (sample_profiles_df["latitude"] < 90).all()
+
+    def test_longitude_within_bounds(self, sample_profiles_df):
+        assert (sample_profiles_df["longitude"] > -180).all()
+        assert (sample_profiles_df["longitude"] < 180).all()
+
+    def test_depth_min_le_depth_max(self, sample_profiles_df):
+        assert (sample_profiles_df["depth_min"] <= sample_profiles_df["depth_max"]).all()
+
+    def test_time_min_before_time_max(self, sample_profiles_df):
+        assert (sample_profiles_df["time_min"] < sample_profiles_df["time_max"]).all()
+
+    def test_n_records_positive(self, sample_profiles_df):
+        assert (sample_profiles_df["n_records"] > 0).all()
+
+    def test_roundtrip_preserves_row_count(self, sample_profiles_df, tmp_path):
+        df = _write_and_read_csv(sample_profiles_df, tmp_path, "profiles.csv")
+        assert len(df) == len(sample_profiles_df)
+
+
+# ---------------------------------------------------------------------------
+# Tests: skipped.csv
+# ---------------------------------------------------------------------------
+
+class TestSkippedCsvStructure:
+    def test_all_required_columns_present(self, sample_skipped_df):
+        for col in REQUIRED_SKIPPED_COLS:
+            assert col in sample_skipped_df.columns
+
+    def test_reason_code_is_non_empty(self, sample_skipped_df):
+        assert (sample_skipped_df["reason_code"] != "").all()
+
+    def test_roundtrip_preserves_data(self, sample_skipped_df, tmp_path):
+        df = _write_and_read_csv(sample_skipped_df, tmp_path, "skipped.csv")
+        assert df["reason_code"].tolist() == sample_skipped_df["reason_code"].tolist()

--- a/tests/unit/test_dataset.py
+++ b/tests/unit/test_dataset.py
@@ -1,0 +1,112 @@
+"""
+Unit tests for cde_harvester.dataset.Dataset.
+
+Dataset.__init__ calls get_metadata() immediately, which calls
+erddap_server.erddap_csv_to_df. The mock_erddap_server fixture wires
+that method to return the standard info fixture so no HTTP calls occur.
+"""
+
+import pandas as pd
+import pytest
+
+from conftest import (
+    DATASET_ID,
+    ERDDAP_INFO_CSV,
+    ERDDAP_INFO_DEPTH_AND_ALTITUDE_CSV,
+    ERDDAP_INFO_INGEST_FALSE_CSV,
+    ERDDAP_INFO_NO_EOVS_CSV,
+    ERDDAP_URL,
+    build_variables_df,
+    mock_erddap_server,  # noqa: F401 — imported for pytest fixture discovery
+)
+
+
+def _make_dataset(server, info_csv=ERDDAP_INFO_CSV):
+    """Create a real Dataset object backed by a mock server."""
+    from io import StringIO
+
+    server.erddap_csv_to_df.side_effect = lambda url, skiprows=None, dataset=None: (
+        pd.read_csv(StringIO(info_csv)).fillna("")
+    )
+    from cde_harvester.dataset import Dataset
+    return Dataset(server, DATASET_ID)
+
+
+class TestDatasetMetadataParsing:
+    def test_id_stored(self, mock_erddap_server):
+        ds = _make_dataset(mock_erddap_server)
+        assert ds.id == DATASET_ID
+
+    def test_erddap_url_stored(self, mock_erddap_server):
+        ds = _make_dataset(mock_erddap_server)
+        assert ds.erddap_url == ERDDAP_URL
+
+    def test_cdm_data_type_parsed(self, mock_erddap_server):
+        ds = _make_dataset(mock_erddap_server)
+        assert ds.cdm_data_type == "TimeSeries"
+
+    def test_globals_dict_populated(self, mock_erddap_server):
+        ds = _make_dataset(mock_erddap_server)
+        assert ds.globals["title"] == "Test Temperature Dataset"
+        assert ds.globals["institution"] == "Test Institution"
+
+    def test_variables_list_contains_expected_vars(self, mock_erddap_server):
+        ds = _make_dataset(mock_erddap_server)
+        for var in ["time", "latitude", "longitude", "depth", "temperature", "station_id"]:
+            assert var in ds.variables_list
+
+    def test_df_variables_index_is_variable_names(self, mock_erddap_server):
+        ds = _make_dataset(mock_erddap_server)
+        assert "temperature" in ds.df_variables.index
+        assert "station_id" in ds.df_variables.index
+
+    def test_standard_name_attribute_parsed(self, mock_erddap_server):
+        ds = _make_dataset(mock_erddap_server)
+        assert ds.df_variables.loc["temperature"]["standard_name"] == "sea_water_temperature"
+
+    def test_cf_role_attribute_parsed(self, mock_erddap_server):
+        ds = _make_dataset(mock_erddap_server)
+        assert ds.df_variables.loc["station_id"]["cf_role"] == "timeseries_id"
+
+    def test_organization_extracted_from_institution(self, mock_erddap_server):
+        ds = _make_dataset(mock_erddap_server)
+        assert "Test Institution" in ds.organizations
+
+    def test_platform_defaults_to_unknown_when_no_platform_global(self, mock_erddap_server):
+        # Our test info CSV has no 'platform' or 'platform_vocabulary' globals
+        ds = _make_dataset(mock_erddap_server)
+        assert ds.platform == "unknown"
+
+
+class TestDatasetEOVMapping:
+    def test_eovs_populated_when_supported_var_present(self, mock_erddap_server):
+        ds = _make_dataset(mock_erddap_server)
+        # sea_water_temperature maps to at least one CDE EOV
+        assert len(ds.eovs) > 0
+
+    def test_eovs_empty_when_no_supported_standard_names(self, mock_erddap_server):
+        ds = _make_dataset(mock_erddap_server, info_csv=ERDDAP_INFO_NO_EOVS_CSV)
+        assert ds.eovs == []
+
+    def test_first_eov_column_set(self, mock_erddap_server):
+        ds = _make_dataset(mock_erddap_server)
+        assert ds.first_eov_column == "temperature"
+
+
+class TestDatasetGetDf:
+    def test_get_df_returns_dataframe(self, mock_erddap_server):
+        from cde_harvester.profiles import get_profiles
+
+        ds = _make_dataset(mock_erddap_server)
+        # get_df requires profile_ids to be set; set a minimal value
+        ds.profile_ids = pd.DataFrame({"station_id": ["S1"], "latitude": [48.5], "longitude": [-125.0]})
+        df = ds.get_df()
+        assert isinstance(df, pd.DataFrame)
+
+    def test_get_df_contains_required_columns(self, mock_erddap_server):
+        ds = _make_dataset(mock_erddap_server)
+        ds.profile_ids = pd.DataFrame({"station_id": ["S1"], "latitude": [48.5], "longitude": [-125.0]})
+        df = ds.get_df()
+        required = ["title", "erddap_url", "dataset_id", "cdm_data_type", "platform", "eovs"]
+        for col in required:
+            assert col in df.columns

--- a/tests/unit/test_db_loader.py
+++ b/tests/unit/test_db_loader.py
@@ -1,0 +1,159 @@
+"""
+Unit tests for cde_db_loader.__main__.
+
+Tests cover:
+1. Pure helper functions (prepare_profiles_dataframe, ensure_organization_pks)
+2. Full-reload mode: correct SQL functions called, data written to right tables
+3. Incremental mode: temp tables created and process_incremental_update called
+"""
+
+from unittest.mock import MagicMock
+
+import pandas as pd
+import pytest
+
+from cde_db_loader.__main__ import (
+    ensure_organization_pks,
+    main,
+    prepare_profiles_dataframe,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def harvest_folder(tmp_path, sample_datasets_df, sample_profiles_df, sample_skipped_df):
+    """Write CSVs as the harvester would and return the folder path string."""
+    sample_datasets_df.to_csv(tmp_path / "datasets.csv", index=False)
+    sample_profiles_df.to_csv(tmp_path / "profiles.csv", index=False)
+    sample_skipped_df.to_csv(tmp_path / "skipped.csv", index=False)
+    return str(tmp_path)
+
+
+@pytest.fixture
+def mock_engine():
+    """SQLAlchemy engine mock. __enter__.return_value sets the transaction object."""
+    engine = MagicMock()
+    conn = MagicMock()
+    engine.begin.return_value.__enter__.return_value = conn
+    engine.begin.return_value.__exit__.return_value = False
+    return engine, conn
+
+
+@pytest.fixture(autouse=True)
+def db_env(monkeypatch):
+    """Inject required env vars so main() can build the DB connection string."""
+    monkeypatch.setenv("DB_USER", "testuser")
+    monkeypatch.setenv("DB_PASSWORD", "testpass")
+    monkeypatch.setenv("DB_HOST_EXTERNAL", "localhost")
+    monkeypatch.setenv("DB_PORT", "5432")
+    monkeypatch.setenv("DB_NAME", "testdb")
+
+
+def _run_main(harvest_folder, mock_engine, mocker, incremental=False):
+    """
+    Shared helper: patch create_engine and capture SQL strings passed to text().
+    Returns the list of SQL strings that were executed.
+    """
+    engine, conn = mock_engine
+    mocker.patch("cde_db_loader.__main__.create_engine", return_value=engine)
+    mocker.patch("cde_db_loader.__main__.load_dotenv")
+    # Capture SQL strings; return the raw string so conn.execute gets it
+    mock_text = mocker.patch(
+        "cde_db_loader.__main__.text", side_effect=lambda s: s
+    )
+    mocker.patch("pandas.DataFrame.to_sql")
+
+    main(harvest_folder, incremental=incremental)
+
+    return [c.args[0] for c in mock_text.call_args_list]
+
+
+# ---------------------------------------------------------------------------
+# Pure function tests
+# ---------------------------------------------------------------------------
+
+class TestPrepareProfilesDataframe:
+    def test_removes_altitude_columns(self, sample_profiles_df):
+        df = sample_profiles_df.copy()
+        df["altitude_min"] = 0.0
+        df["altitude_max"] = 0.0
+        result = prepare_profiles_dataframe(df)
+        assert "altitude_min" not in result.columns
+        assert "altitude_max" not in result.columns
+
+    def test_drops_rows_where_time_min_is_null(self, sample_profiles_df):
+        df = sample_profiles_df.copy()
+        df.loc[0, "time_min"] = None
+        result = prepare_profiles_dataframe(df)
+        assert len(result) == 0
+
+    def test_replaces_empty_strings_with_nan(self, sample_profiles_df):
+        df = sample_profiles_df.copy()
+        df["timeseries_id"] = ""
+        result = prepare_profiles_dataframe(df)
+        assert pd.isna(result["timeseries_id"].iloc[0])
+
+    def test_valid_rows_preserved(self, sample_profiles_df):
+        result = prepare_profiles_dataframe(sample_profiles_df.copy())
+        assert len(result) == len(sample_profiles_df)
+
+
+class TestEnsureOrganizationPks:
+    def test_missing_column_gets_empty_arrays(self, sample_datasets_df):
+        df = sample_datasets_df.drop(
+            columns=["organization_pks"],
+            errors="ignore",
+        )
+        result = ensure_organization_pks(df)
+        assert "organization_pks" in result.columns
+        assert all(isinstance(v, list) for v in result["organization_pks"])
+
+    def test_null_values_replaced_with_empty_lists(self, sample_datasets_df):
+        df = sample_datasets_df.copy()
+        df["organization_pks"] = None
+        result = ensure_organization_pks(df)
+        assert all(isinstance(v, list) for v in result["organization_pks"])
+
+
+# ---------------------------------------------------------------------------
+# main() — full reload mode
+# ---------------------------------------------------------------------------
+
+class TestDbLoaderMainFullReload:
+    def test_drop_constraints_called(self, harvest_folder, mock_engine, mocker):
+        sql_calls = _run_main(harvest_folder, mock_engine, mocker, incremental=False)
+        assert any("drop_constraints" in s for s in sql_calls)
+
+    def test_remove_all_data_called(self, harvest_folder, mock_engine, mocker):
+        sql_calls = _run_main(harvest_folder, mock_engine, mocker, incremental=False)
+        assert any("remove_all_data" in s for s in sql_calls)
+
+    def test_profile_process_called(self, harvest_folder, mock_engine, mocker):
+        sql_calls = _run_main(harvest_folder, mock_engine, mocker, incremental=False)
+        assert any("profile_process" in s for s in sql_calls)
+
+    def test_set_constraints_called(self, harvest_folder, mock_engine, mocker):
+        sql_calls = _run_main(harvest_folder, mock_engine, mocker, incremental=False)
+        assert any("set_constraints" in s for s in sql_calls)
+
+
+# ---------------------------------------------------------------------------
+# main() — incremental mode
+# ---------------------------------------------------------------------------
+
+class TestDbLoaderMainIncremental:
+    def test_create_temp_tables_called(self, harvest_folder, mock_engine, mocker):
+        sql_calls = _run_main(harvest_folder, mock_engine, mocker, incremental=True)
+        assert any("create_temp_tables" in s for s in sql_calls)
+
+    def test_process_incremental_update_called(self, harvest_folder, mock_engine, mocker):
+        sql_calls = _run_main(harvest_folder, mock_engine, mocker, incremental=True)
+        assert any("process_incremental_update" in s for s in sql_calls)
+
+    def test_drop_constraints_not_called_in_incremental(self, harvest_folder, mock_engine, mocker):
+        sql_calls = _run_main(harvest_folder, mock_engine, mocker, incremental=True)
+        assert not any("drop_constraints" in s for s in sql_calls)
+        assert not any("remove_all_data" in s for s in sql_calls)

--- a/tests/unit/test_erddap_client.py
+++ b/tests/unit/test_erddap_client.py
@@ -1,0 +1,148 @@
+"""
+Unit tests for cde_harvester.ERDDAP — the HTTP client that talks to ERDDAP servers.
+
+All HTTP calls are intercepted by patching requests.Session so no network
+traffic is produced.
+"""
+
+from io import StringIO
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+import requests
+
+from conftest import (
+    ERDDAP_ALL_DATASETS_CSV,
+    ERDDAP_INFO_CSV,
+    ERDDAP_URL,
+    MockResponse,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_erddap(all_datasets_csv=ERDDAP_ALL_DATASETS_CSV):
+    """Create an ERDDAP instance with a mocked session.get."""
+    with patch("cde_harvester.ERDDAP.requests") as mock_requests:
+        mock_session = MagicMock()
+        mock_requests.Session.return_value = mock_session
+        mock_session.get.return_value = MockResponse(
+            text=all_datasets_csv, url=ERDDAP_URL + "/tabledap/allDatasets.csv"
+        )
+        from cde_harvester.ERDDAP import ERDDAP
+        erddap = ERDDAP(ERDDAP_URL, cache_requests=False)
+        erddap.session = mock_session  # expose for further assertions
+    return erddap
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestERDDAPInit:
+    def test_url_is_stored(self):
+        erddap = _make_erddap()
+        assert erddap.url == ERDDAP_URL
+
+    def test_domain_extracted_from_url(self):
+        erddap = _make_erddap()
+        assert erddap.domain == "test.erddap.com"
+
+    def test_get_all_datasets_returns_dataframe(self):
+        erddap = _make_erddap()
+        assert isinstance(erddap.df_all_datasets, pd.DataFrame)
+
+    def test_get_all_datasets_has_expected_columns(self):
+        erddap = _make_erddap()
+        assert "datasetID" in erddap.df_all_datasets.columns
+        assert "cdm_data_type" in erddap.df_all_datasets.columns
+
+    def test_get_all_datasets_skips_units_rows(self):
+        """Rows at index 1 and 2 (units + type rows) must be dropped."""
+        erddap = _make_erddap()
+        ids = erddap.df_all_datasets["datasetID"].tolist()
+        # The "(String)" units row must NOT appear
+        assert "(String)" not in ids
+        assert "test_timeseries_001" in ids
+
+    def test_empty_response_gives_empty_dataframe(self):
+        empty_csv = "datasetID,cdm_data_type\n(String),(String)\n,\n"
+        with patch("cde_harvester.ERDDAP.requests") as mock_requests:
+            mock_session = MagicMock()
+            mock_requests.Session.return_value = mock_session
+            mock_session.get.return_value = MockResponse(
+                text=empty_csv, url=ERDDAP_URL + "/tabledap/allDatasets.csv"
+            )
+            from cde_harvester.ERDDAP import ERDDAP
+            erddap = ERDDAP(ERDDAP_URL, cache_requests=False)
+        assert erddap.df_all_datasets.empty
+
+
+class TestErddapCsvToDf:
+    def test_200_response_returns_dataframe(self):
+        erddap = _make_erddap()
+        erddap.session.get.return_value = MockResponse(
+            text=ERDDAP_INFO_CSV, url=ERDDAP_URL + "/info/ds/index.csv"
+        )
+        df = erddap.erddap_csv_to_df("/info/test/index.csv", skiprows=[])
+        assert isinstance(df, pd.DataFrame)
+        assert not df.empty
+
+    def test_404_returns_empty_dataframe(self):
+        erddap = _make_erddap()
+        erddap.session.get.return_value = MockResponse(
+            text="Not found", status_code=404,
+            url=ERDDAP_URL + "/tabledap/missing.csv"
+        )
+        df = erddap.erddap_csv_to_df("/tabledap/missing.csv")
+        assert df.empty
+
+    def test_500_no_matching_results_returns_empty(self):
+        erddap = _make_erddap()
+        erddap.session.get.return_value = MockResponse(
+            text="Your query produced no matching results",
+            status_code=500,
+            url=ERDDAP_URL + "/tabledap/ds.csv"
+        )
+        df = erddap.erddap_csv_to_df("/tabledap/ds.csv")
+        assert df.empty
+
+    def test_500_other_error_raises(self):
+        erddap = _make_erddap()
+        erddap.session.get.return_value = MockResponse(
+            text="Internal Server Error", status_code=500,
+            url=ERDDAP_URL + "/tabledap/ds.csv"
+        )
+        with pytest.raises(requests.exceptions.HTTPError):
+            erddap.erddap_csv_to_df("/tabledap/ds.csv")
+
+    def test_response_too_large_raises(self):
+        erddap = _make_erddap()
+        big_content = b"x" * int(2e8 + 1)
+        mock_resp = MockResponse(text="", url=ERDDAP_URL)
+        mock_resp.content = big_content
+        erddap.session.get.return_value = mock_resp
+        with pytest.raises(RuntimeError, match="too big"):
+            erddap.erddap_csv_to_df("/tabledap/ds.csv")
+
+
+class TestParseErddapDate:
+    def test_iso8601_string(self):
+        from cde_harvester.ERDDAP import ERDDAP
+        result = ERDDAP.parse_erddap_date("2020-06-15T00:00:00Z")
+        assert result.year == 2020
+        assert result.month == 6
+
+    def test_large_epoch_is_not_timestamp(self):
+        """Values like 1577836800.0 do NOT start with '1.' so treated as ISO."""
+        from cde_harvester.ERDDAP import ERDDAP
+        # A scientific-notation epoch starting with "1." IS a timestamp
+        result = ERDDAP.parse_erddap_date("1.5E9")
+        assert pd.notna(result)
+
+    def test_invalid_string_returns_nat(self):
+        from cde_harvester.ERDDAP import ERDDAP
+        result = ERDDAP.parse_erddap_date("not-a-date")
+        assert pd.isna(result)

--- a/tests/unit/test_harvest_erddap.py
+++ b/tests/unit/test_harvest_erddap.py
@@ -1,0 +1,153 @@
+"""
+Unit tests for cde_harvester.harvest_erddap.harvest_erddap.
+
+The ERDDAP class constructor is patched so no HTTP calls are made.
+Individual Dataset objects are returned as pre-built MagicMocks.
+"""
+
+import pandas as pd
+import pytest
+from unittest.mock import MagicMock, patch
+
+from conftest import (
+    DATASET_ID,
+    ERDDAP_URL,
+    build_mock_dataset,
+)
+from cde_harvester.harvest_erddap import harvest_erddap
+from cde_harvester.harvest_errors import (
+    CDM_DATA_TYPE_UNSUPPORTED,
+    HTTP_ERROR,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+def _make_erddap_mock(datasets: list[tuple], domain: str = "test.erddap.com"):
+    """
+    Build a mock ERDDAP instance whose df_all_datasets contains the given rows.
+    Each tuple is (datasetID, cdm_data_type).
+    """
+    mock_erddap = MagicMock()
+    mock_erddap.domain = domain
+    mock_erddap.url = ERDDAP_URL
+
+    df = pd.DataFrame(datasets, columns=["datasetID", "cdm_data_type"])
+    mock_erddap.df_all_datasets = df
+    mock_erddap.get_logger.return_value = __import__("logging").getLogger("test")
+    return mock_erddap
+
+
+def _run_harvest(erddap_mock, dataset_mock=None, limit=None):
+    """
+    Patch harvest_erddap.ERDDAP and get_profiles, then call harvest_erddap().
+    Returns the result list.
+    """
+    with (
+        patch("cde_harvester.harvest_erddap.ERDDAP", return_value=erddap_mock),
+        patch("cde_harvester.harvest_erddap.get_profiles") as mock_get_profiles,
+    ):
+        if dataset_mock is None:
+            dataset_mock = build_mock_dataset()
+
+        # get_profiles returns a simple single-row DataFrame
+        from io import StringIO
+        profiles_df = pd.DataFrame({
+            "timeseries_id": ["STATION_001"],
+            "latitude": [48.5],
+            "longitude": [-125.0],
+            "time_min": ["2020-01-01"],
+            "time_max": ["2023-12-31"],
+            "depth_min": [0.5],
+            "depth_max": [200.5],
+            "n_records": [1000.0],
+            "records_per_day": [0.75],
+            "dataset_id": [DATASET_ID],
+            "erddap_url": [ERDDAP_URL],
+            "profile_id": [""],
+        })
+        mock_get_profiles.return_value = profiles_df
+
+        erddap_mock.get_dataset.return_value = dataset_mock
+
+        result = []
+        harvest_erddap(ERDDAP_URL, result, limit_dataset_ids=limit)
+        return result
+
+
+class TestHarvestErddapHappyPath:
+    def test_result_appended(self):
+        erddap_mock = _make_erddap_mock([
+            (DATASET_ID, "TimeSeries"),
+        ])
+        result = _run_harvest(erddap_mock)
+        assert len(result) == 1
+
+    def test_result_contains_four_dataframes(self):
+        erddap_mock = _make_erddap_mock([(DATASET_ID, "TimeSeries")])
+        result = _run_harvest(erddap_mock)
+        profiles, datasets, variables, skipped = result[0]
+        assert isinstance(profiles, pd.DataFrame)
+        assert isinstance(datasets, pd.DataFrame)
+        assert isinstance(variables, pd.DataFrame)
+        assert isinstance(skipped, pd.DataFrame)
+
+    def test_compliant_dataset_appears_in_datasets(self):
+        erddap_mock = _make_erddap_mock([(DATASET_ID, "TimeSeries")])
+        result = _run_harvest(erddap_mock)
+        _, datasets, _, _ = result[0]
+        assert DATASET_ID in datasets["dataset_id"].values
+
+    def test_dataset_id_filter_respected(self):
+        erddap_mock = _make_erddap_mock([
+            (DATASET_ID, "TimeSeries"),
+            ("other_dataset", "TimeSeries"),
+        ])
+        result = _run_harvest(erddap_mock, limit=[DATASET_ID])
+        _, datasets, _, _ = result[0]
+        # Only the filtered ID should appear
+        assert DATASET_ID in datasets["dataset_id"].values
+        assert "other_dataset" not in datasets["dataset_id"].values
+
+
+class TestHarvestErddapSkipping:
+    def test_unsupported_cdm_type_skipped(self):
+        erddap_mock = _make_erddap_mock([("bad_ds", "Point")])
+        result = _run_harvest(erddap_mock)
+        _, _, _, skipped = result[0]
+        assert "bad_ds" in skipped["dataset_id"].values
+        assert CDM_DATA_TYPE_UNSUPPORTED in skipped["reason_code"].values
+
+    def test_non_compliant_dataset_added_to_skipped(self):
+        """A dataset that fails compliance checks should appear in skipped."""
+        from conftest import ERDDAP_INFO_NO_EOVS_CSV
+        non_compliant = build_mock_dataset(ERDDAP_INFO_NO_EOVS_CSV)
+        erddap_mock = _make_erddap_mock([(DATASET_ID, "TimeSeries")])
+        result = _run_harvest(erddap_mock, dataset_mock=non_compliant)
+        _, datasets, _, skipped = result[0]
+        assert DATASET_ID not in datasets["dataset_id"].values
+        assert DATASET_ID in skipped["dataset_id"].values
+
+    def test_http_error_adds_to_skipped(self):
+        import requests
+        erddap_mock = _make_erddap_mock([(DATASET_ID, "TimeSeries")])
+
+        # Make get_dataset raise an HTTPError
+        mock_response = MagicMock()
+        mock_response.status_code = 500
+        mock_response.reason = "Internal Server Error"
+        erddap_mock.get_dataset.side_effect = requests.exceptions.HTTPError(
+            response=mock_response
+        )
+
+        with (
+            patch("cde_harvester.harvest_erddap.ERDDAP", return_value=erddap_mock),
+            patch("cde_harvester.harvest_erddap.get_profiles"),
+        ):
+            result = []
+            harvest_erddap(ERDDAP_URL, result)
+
+        _, _, _, skipped = result[0]
+        assert HTTP_ERROR in skipped["reason_code"].values

--- a/tests/unit/test_profiles.py
+++ b/tests/unit/test_profiles.py
@@ -1,0 +1,123 @@
+"""
+Unit tests for cde_harvester.profiles.get_profiles.
+
+Uses a fully-configured MagicMock dataset so that get_profiles can exercise
+its real logic (DataFrame manipulation, bad-geometry filtering, etc.) without
+any HTTP calls.
+"""
+
+import pandas as pd
+import pytest
+
+from conftest import (
+    DATASET_ID,
+    ERDDAP_PROFILE_IDS_CSV,
+    ERDDAP_URL,
+    build_mock_dataset,
+)
+from cde_harvester.profiles import get_profiles
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def single_station_dataset():
+    """Mock dataset with a single TimeSeries station — uses actual_range path."""
+    return build_mock_dataset()
+
+
+@pytest.fixture
+def no_profile_dataset(single_station_dataset):
+    """Dataset whose get_profile_ids() returns an empty DataFrame."""
+    single_station_dataset.get_profile_ids.return_value = pd.DataFrame()
+    return single_station_dataset
+
+
+@pytest.fixture
+def bad_geometry_dataset(single_station_dataset):
+    """Dataset whose single profile has a latitude out of valid range."""
+    bad_ids = pd.DataFrame({
+        "station_id": ["BAD_STATION"],
+        "latitude": [95.0],   # > 90 → invalid
+        "longitude": [-125.0],
+    })
+    single_station_dataset.get_profile_ids.return_value = bad_ids
+    single_station_dataset.profile_ids = bad_ids
+    return single_station_dataset
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestGetProfilesHappyPath:
+    def test_returns_dataframe(self, single_station_dataset):
+        result = get_profiles(single_station_dataset)
+        assert isinstance(result, pd.DataFrame)
+
+    def test_result_is_not_empty(self, single_station_dataset):
+        result = get_profiles(single_station_dataset)
+        assert not result.empty
+
+    def test_required_columns_present(self, single_station_dataset):
+        result = get_profiles(single_station_dataset)
+        required = [
+            "timeseries_id", "latitude", "longitude",
+            "time_min", "time_max", "depth_min", "depth_max",
+            "n_records", "records_per_day", "dataset_id", "erddap_url",
+        ]
+        for col in required:
+            assert col in result.columns, f"Missing column: {col}"
+
+    def test_dataset_id_matches(self, single_station_dataset):
+        result = get_profiles(single_station_dataset)
+        assert (result["dataset_id"] == DATASET_ID).all()
+
+    def test_erddap_url_matches(self, single_station_dataset):
+        result = get_profiles(single_station_dataset)
+        assert (result["erddap_url"] == ERDDAP_URL).all()
+
+    def test_latitude_preserved(self, single_station_dataset):
+        result = get_profiles(single_station_dataset)
+        assert result["latitude"].iloc[0] == pytest.approx(48.5)
+
+    def test_longitude_preserved(self, single_station_dataset):
+        result = get_profiles(single_station_dataset)
+        assert result["longitude"].iloc[0] == pytest.approx(-125.0)
+
+    def test_time_min_is_datetime(self, single_station_dataset):
+        result = get_profiles(single_station_dataset)
+        assert pd.api.types.is_datetime64_any_dtype(result["time_min"])
+
+    def test_depth_defaults_to_zero_when_no_depth_var(self, single_station_dataset):
+        """If the dataset has no depth variable, depth_min and depth_max default to 0."""
+        single_station_dataset.variables_list = [
+            v for v in single_station_dataset.variables_list if v != "depth"
+        ]
+        result = get_profiles(single_station_dataset)
+        assert not result.empty
+        assert (result["depth_min"] == 0).all()
+        assert (result["depth_max"] == 0).all()
+
+    def test_records_per_day_is_positive(self, single_station_dataset):
+        result = get_profiles(single_station_dataset)
+        assert (result["records_per_day"] > 0).all()
+
+
+class TestGetProfilesEmptyAndEdgeCases:
+    def test_empty_profile_ids_returns_empty(self, no_profile_dataset):
+        result = get_profiles(no_profile_dataset)
+        assert result.empty
+
+    def test_bad_latitude_profile_filtered_out(self, bad_geometry_dataset):
+        """Profiles with latitude > 90 must be removed by the bad-geometry filter."""
+        result = get_profiles(bad_geometry_dataset)
+        assert result.empty
+
+    def test_profile_id_column_added_when_missing(self, single_station_dataset):
+        """timeSeries datasets have no profile_id variable; it should default to empty string."""
+        result = get_profiles(single_station_dataset)
+        assert "profile_id" in result.columns
+        assert (result["profile_id"] == "").all()

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,0 +1,67 @@
+"""
+Unit tests for cde_harvester.utils — EOV/CF standard name mappings and helpers.
+"""
+
+import pytest
+
+from cde_harvester.utils import (
+    cde_eov_to_standard_name,
+    df_cde_eov_to_standard_name,
+    get_cde_eov_to_standard_name,
+    intersection,
+    supported_standard_names,
+)
+
+
+class TestIntersection:
+    def test_returns_common_elements(self):
+        assert intersection(["a", "b", "c"], ["b", "c", "d"]) == ["b", "c"]
+
+    def test_returns_empty_when_no_overlap(self):
+        assert intersection(["a", "b"], ["c", "d"]) == []
+
+    def test_excludes_empty_strings(self):
+        result = intersection(["", "a", "b"], ["", "a"])
+        assert "" not in result
+        assert "a" in result
+
+    def test_order_follows_first_list(self):
+        result = intersection(["c", "b", "a"], ["a", "b", "c"])
+        assert result == ["c", "b", "a"]
+
+    def test_empty_lists_return_empty(self):
+        assert intersection([], []) == []
+
+
+class TestCdeEovMappings:
+    def test_mapping_is_non_empty(self):
+        assert len(cde_eov_to_standard_name) > 0
+
+    def test_most_eovs_map_to_at_least_one_standard_name(self):
+        # Some EOVs (e.g. fishAbundanceAndDistribution) have no CF standard names
+        # by design — they're monitored via non-CF methods. Verify the majority do.
+        eovs_with_names = [eov for eov, names in cde_eov_to_standard_name.items() if names]
+        assert len(eovs_with_names) > len(cde_eov_to_standard_name) // 2
+
+    def test_sea_water_temperature_is_supported(self):
+        assert "sea_water_temperature" in supported_standard_names
+
+    def test_df_has_expected_columns(self):
+        assert "eov" in df_cde_eov_to_standard_name.columns
+        assert "standard_name" in df_cde_eov_to_standard_name.columns
+
+    def test_df_rows_match_mapping(self):
+        """Every row in the DataFrame must correspond to a valid (eov, standard_name) pair."""
+        for _, row in df_cde_eov_to_standard_name.iterrows():
+            eov = row["eov"]
+            sn = row["standard_name"]
+            assert eov in cde_eov_to_standard_name
+            assert sn in cde_eov_to_standard_name[eov]
+
+    def test_goos_and_cde_layers_both_collapsed(self):
+        """get_cde_eov_to_standard_name should hide the GOOS intermediate layer."""
+        mapping = get_cde_eov_to_standard_name()
+        # Top-level keys are CDE EOVs, not GOOS EOVs
+        assert isinstance(mapping, dict)
+        for key in mapping:
+            assert isinstance(key, str)

--- a/tests/uv.lock
+++ b/tests/uv.lock
@@ -1,0 +1,573 @@
+version = 1
+revision = 2
+requires-python = "==3.10.*"
+
+[[package]]
+name = "anyio"
+version = "4.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "exceptiongroup" },
+    { name = "idna" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.5.20"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/ce/ee2ecad540810a79593028e88299baeae54d346cc7a0d94b6199988b89b1/certifi-2026.5.20.tar.gz", hash = "sha256:69dea482ab64caa7b9f6aba1c6bf48bb6a5448d1c0f1b17ab42ad8c763a5344d", size = 135422, upload-time = "2026-05-20T11:46:50.073Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/59/8c/57e832b7af6d7c5abe66eb3fbe3a3a32f4d11ea23a1aa7131371035be991/certifi-2026.5.20-py3-none-any.whl", hash = "sha256:3c52e209ba0a4ad7aebe60436a4ab349c39e1e602e8c134221e546902ad25897", size = 134134, upload-time = "2026-05-20T11:46:48.578Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz", hash = "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5", size = 144271, upload-time = "2026-04-02T09:28:39.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/26/08/0f303cb0b529e456bb116f2d50565a482694fbb94340bf56d44677e7ed03/charset_normalizer-3.4.7-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:cdd68a1fb318e290a2077696b7eb7a21a49163c455979c639bf5a5dcdc46617d", size = 315182, upload-time = "2026-04-02T09:25:40.673Z" },
+    { url = "https://files.pythonhosted.org/packages/24/47/b192933e94b546f1b1fe4df9cc1f84fcdbf2359f8d1081d46dd029b50207/charset_normalizer-3.4.7-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e17b8d5d6a8c47c85e68ca8379def1303fd360c3e22093a807cd34a71cd082b8", size = 209329, upload-time = "2026-04-02T09:25:42.354Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/b4/01fa81c5ca6141024d89a8fc15968002b71da7f825dd14113207113fabbd/charset_normalizer-3.4.7-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:511ef87c8aec0783e08ac18565a16d435372bc1ac25a91e6ac7f5ef2b0bff790", size = 231230, upload-time = "2026-04-02T09:25:44.281Z" },
+    { url = "https://files.pythonhosted.org/packages/20/f7/7b991776844dfa058017e600e6e55ff01984a063290ca5622c0b63162f68/charset_normalizer-3.4.7-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:007d05ec7321d12a40227aae9e2bc6dca73f3cb21058999a1df9e193555a9dcc", size = 225890, upload-time = "2026-04-02T09:25:45.475Z" },
+    { url = "https://files.pythonhosted.org/packages/20/e7/bed0024a0f4ab0c8a9c64d4445f39b30c99bd1acd228291959e3de664247/charset_normalizer-3.4.7-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cf29836da5119f3c8a8a70667b0ef5fdca3bb12f80fd06487cfa575b3909b393", size = 216930, upload-time = "2026-04-02T09:25:46.58Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/ab/b18f0ab31cdd7b3ddb8bb76c4a414aeb8160c9810fdf1bc62f269a539d87/charset_normalizer-3.4.7-cp310-cp310-manylinux_2_31_armv7l.whl", hash = "sha256:12d8baf840cc7889b37c7c770f478adea7adce3dcb3944d02ec87508e2dcf153", size = 202109, upload-time = "2026-04-02T09:25:48.031Z" },
+    { url = "https://files.pythonhosted.org/packages/82/e5/7e9440768a06dfb3075936490cb82dbf0ee20a133bf0dd8551fa096914ec/charset_normalizer-3.4.7-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d560742f3c0d62afaccf9f41fe485ed69bd7661a241f86a3ef0f0fb8b1a397af", size = 214684, upload-time = "2026-04-02T09:25:49.245Z" },
+    { url = "https://files.pythonhosted.org/packages/71/94/8c61d8da9f062fdf457c80acfa25060ec22bf1d34bbeaca4350f13bcfd07/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:b14b2d9dac08e28bb8046a1a0434b1750eb221c8f5b87a68f4fa11a6f97b5e34", size = 212785, upload-time = "2026-04-02T09:25:50.671Z" },
+    { url = "https://files.pythonhosted.org/packages/66/cd/6e9889c648e72c0ab2e5967528bb83508f354d706637bc7097190c874e13/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:bc17a677b21b3502a21f66a8cc64f5bfad4df8a0b8434d661666f8ce90ac3af1", size = 203055, upload-time = "2026-04-02T09:25:51.802Z" },
+    { url = "https://files.pythonhosted.org/packages/92/2e/7a951d6a08aefb7eb8e1b54cdfb580b1365afdd9dd484dc4bee9e5d8f258/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:750e02e074872a3fad7f233b47734166440af3cdea0add3e95163110816d6752", size = 232502, upload-time = "2026-04-02T09:25:53.388Z" },
+    { url = "https://files.pythonhosted.org/packages/58/d5/abcf2d83bf8e0a1286df55cd0dc1d49af0da4282aa77e986df343e7de124/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:4e5163c14bffd570ef2affbfdd77bba66383890797df43dc8b4cc7d6f500bf53", size = 214295, upload-time = "2026-04-02T09:25:54.765Z" },
+    { url = "https://files.pythonhosted.org/packages/47/3a/7d4cd7ed54be99973a0dc176032cba5cb1f258082c31fa6df35cff46acfc/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:6ed74185b2db44f41ef35fd1617c5888e59792da9bbc9190d6c7300617182616", size = 227145, upload-time = "2026-04-02T09:25:55.904Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/98/3a45bf8247889cf28262ebd3d0872edff11565b2a1e3064ccb132db3fbb0/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:94e1885b270625a9a828c9793b4d52a64445299baa1fea5a173bf1d3dd9a1a5a", size = 218884, upload-time = "2026-04-02T09:25:57.074Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/80/2e8b7f8915ed5c9ef13aa828d82738e33888c485b65ebf744d615040c7ea/charset_normalizer-3.4.7-cp310-cp310-win32.whl", hash = "sha256:6785f414ae0f3c733c437e0f3929197934f526d19dfaa75e18fdb4f94c6fb374", size = 148343, upload-time = "2026-04-02T09:25:58.199Z" },
+    { url = "https://files.pythonhosted.org/packages/35/1b/3b8c8c77184af465ee9ad88b5aea46ea6b2e1f7b9dc9502891e37af21e30/charset_normalizer-3.4.7-cp310-cp310-win_amd64.whl", hash = "sha256:6696b7688f54f5af4462118f0bfa7c1621eeb87154f77fa04b9295ce7a8f2943", size = 159174, upload-time = "2026-04-02T09:25:59.322Z" },
+    { url = "https://files.pythonhosted.org/packages/be/c1/feb40dca40dbb21e0a908801782d9288c64fc8d8e562c2098e9994c8c21b/charset_normalizer-3.4.7-cp310-cp310-win_arm64.whl", hash = "sha256:66671f93accb62ed07da56613636f3641f1a12c13046ce91ffc923721f23c008", size = 147805, upload-time = "2026-04-02T09:26:00.756Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl", hash = "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d", size = 61958, upload-time = "2026-04-02T09:28:37.794Z" },
+]
+
+[[package]]
+name = "cioos-harvester-tests"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "db-loader" },
+    { name = "harvester" },
+    { name = "pytest" },
+    { name = "pytest-cov" },
+    { name = "pytest-mock" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "db-loader", editable = "../db-loader" },
+    { name = "harvester", editable = "../harvester" },
+    { name = "pytest", specifier = ">=8.2" },
+    { name = "pytest-cov", specifier = ">=5.0" },
+    { name = "pytest-mock", specifier = ">=3.14" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "coverage"
+version = "7.14.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/fd/0ab2772530e946e1be1abd0bc09e647ec9b02e88f0867857601fefca8953/coverage-7.14.1.tar.gz", hash = "sha256:30c08f7d90415aa98b3c990385dea2939b0da55f38515e5b369b83655f8523be", size = 920132, upload-time = "2026-05-26T20:41:36.783Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/92/69/0d2ef01ff4b8fcecd4cba920d11e92fa4f96ae412441d3b56a90a258e69b/coverage-7.14.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:3e3680291c4a1d0dadfa84a2c459576a4af5133abb617905714339a0c73138cf", size = 219722, upload-time = "2026-05-26T20:38:14.002Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ae/9afdeaa31b9d9ce98124b6abf8bb49119bf71aecae04f8567c189d91299f/coverage-7.14.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a5274669f37f2343635a347b91a60777621341ab3378e9c6ac9335eee704bddf", size = 220240, upload-time = "2026-05-26T20:38:17.424Z" },
+    { url = "https://files.pythonhosted.org/packages/51/69/c998589871df7ea7dba865cc5ee32b5a3e1d47ba6c68ef91104c7c46fa5e/coverage-7.14.1-cp310-cp310-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:cfe5a5fec635799ef33428f1e5e61bafa45a92a96190ba731561ba558ccc214d", size = 246981, upload-time = "2026-05-26T20:38:19.266Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/10/1c7d04c13040dac531d21b712bbe08f902e6dd9b58f5d77875c4d030f8f2/coverage-7.14.1-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:62a9f70b52e0b5a95cfef4a5c5641b06983cadc5e538a3feeb5c00211f523ac2", size = 248812, upload-time = "2026-05-26T20:38:20.75Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/65/2a38a4607ef27cadcfbcee034dba5830ae2569f90144a0f4c7dbf47d30b0/coverage-7.14.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3c18ebc343e15be53049b3a2dce38fe82d58f37e20ab9094b3a39c0aa4f6bb47", size = 250675, upload-time = "2026-05-26T20:38:22.159Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/a2/a446ed9752a4a59b79e0fb6cbb319f6facb2183045c0725462625e66f87e/coverage-7.14.1-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b84ffdf877644e7096aa936991efeed873f7f3df57b9cd001312b7668ab08550", size = 252590, upload-time = "2026-05-26T20:38:23.63Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/fd/e81fbd7ba752365546e9842b1cbdaad3d6919d2a522c590aef16a281ec5e/coverage-7.14.1-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e854312c4103f2ad4c0dc023b69b77ebfd2c89db5f86c4c94dc2353f9a92167e", size = 247691, upload-time = "2026-05-26T20:38:25.057Z" },
+    { url = "https://files.pythonhosted.org/packages/53/35/f3c26fdaae9ea937d154ca4d372e5ea0a4167ff70d36c6074ac2eacb2f83/coverage-7.14.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:c643734307300234fafa36bf2a040a7235f8f177ea1fd6ec1423aea6fb7b929f", size = 248716, upload-time = "2026-05-26T20:38:26.406Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/14/940b6c49551fd343e8507ee2b0ba7af5d0aa04ed5bf768285cb7c72a9884/coverage-7.14.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:84ac9499e48700399a5dd0ea7085b5091961fec52c68d66b4ec0d3cf7f4441b1", size = 246721, upload-time = "2026-05-26T20:38:28.282Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/2c/40fc0634186c28292a662dff578866b3913983d6c375a3c2a74020938719/coverage-7.14.1-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:7f02d09f70776579b926d889a4c9c235070a1f47c40458aeaca563fae5acfdb5", size = 250533, upload-time = "2026-05-26T20:38:29.753Z" },
+    { url = "https://files.pythonhosted.org/packages/de/e3/2c26bf1e811f9df991ff2a9bdddebdd13ee0665d564df7d05979f9146297/coverage-7.14.1-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:ce66d8e46da2bb5ee313a745cbd2e391d319176c1f7a9451bfcd3a2fb920859b", size = 246990, upload-time = "2026-05-26T20:38:31.516Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/b0/060260ef56bd92363ebdce0c7095ce422b06e69aae71828efeca473ab1ca/coverage-7.14.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:c912c259304cfb5ee584481cfb7ce1ff932b4d61e6c9140b8f19cb7b5ed82332", size = 247593, upload-time = "2026-05-26T20:38:33.065Z" },
+    { url = "https://files.pythonhosted.org/packages/63/f3/501502046efeb0d6d94b5ca54941d95f1184183dd6bdb7f283985783bb4a/coverage-7.14.1-cp310-cp310-win32.whl", hash = "sha256:1238cb94638e610e972c60dac68e813f868dc7d6e982535270558443058d9d59", size = 222330, upload-time = "2026-05-26T20:38:35.36Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/5d/1bf99f2c558f128faf7906817ccbdb576ba815d3b41ce2ac1719b70a3663/coverage-7.14.1-cp310-cp310-win_amd64.whl", hash = "sha256:fc459e5d73be2d6332fcfe8dbf3d8994671fe33c700f4565988ecfa511547253", size = 223261, upload-time = "2026-05-26T20:38:37.196Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/3c/1a983b9a745d7f83d53f057bcc5bf79ba6a2bbc08266b3f0c7d6fe630c9b/coverage-7.14.1-py3-none-any.whl", hash = "sha256:a252f21c27e38347e60111a3266b03827422a7d5525951aceee313aa68bab1d2", size = 211815, upload-time = "2026-05-26T20:41:34.078Z" },
+]
+
+[package.optional-dependencies]
+toml = [
+    { name = "tomli" },
+]
+
+[[package]]
+name = "db-loader"
+version = "0.1.0"
+source = { editable = "../db-loader" }
+dependencies = [
+    { name = "numpy" },
+    { name = "pandas" },
+    { name = "psycopg2-binary" },
+    { name = "python-dotenv" },
+    { name = "sentry-sdk" },
+    { name = "sqlalchemy" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "numpy", specifier = "<2.0.0" },
+    { name = "pandas", specifier = "<2.0.0" },
+    { name = "psycopg2-binary", specifier = ">=2.9.10" },
+    { name = "python-dotenv", specifier = ">=1.1.1" },
+    { name = "sentry-sdk", specifier = ">=2.38.0" },
+    { name = "sqlalchemy", specifier = "<2.0.0" },
+]
+
+[[package]]
+name = "diskcache"
+version = "5.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3f/21/1c1ffc1a039ddcc459db43cc108658f32c57d271d7289a2794e401d0fdb6/diskcache-5.6.3.tar.gz", hash = "sha256:2c3a3fa2743d8535d832ec61c2054a1641f41775aa7c556758a109941e33e4fc", size = 67916, upload-time = "2023-08-31T06:12:00.316Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/27/4570e78fc0bf5ea0ca45eb1de3818a23787af9b390c0b0a0033a1b8236f9/diskcache-5.6.3-py3-none-any.whl", hash = "sha256:5e31b2d5fbad117cc363ebaf6b689474db18a1f6438bc82358b024abd4c2ca19", size = 45550, upload-time = "2023-08-31T06:11:58.822Z" },
+]
+
+[[package]]
+name = "erddapy"
+version = "3.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "pandas" },
+    { name = "pytz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/64/ec/22fde80f79ddce03b1fcba3ac660d3acba68640fe3574d2d071fd180f079/erddapy-3.1.1.tar.gz", hash = "sha256:a9f3209fa64393787794d0d0c3b71c2b4b185a8ec332e2635c323033468445ee", size = 23371, upload-time = "2026-03-06T15:48:36.139Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/01/872d32294f719d09aa64dfa6cfd3eb8ec4d9c8c997f1c3432717acbb8cc9/erddapy-3.1.1-py3-none-any.whl", hash = "sha256:fb376ec33a466973d3bd8d603fb8962f9c1e6801cf8e0b3ae8be610611c5075e", size = 26536, upload-time = "2026-03-06T15:48:34.604Z" },
+]
+
+[[package]]
+name = "exceptiongroup"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
+name = "greenlet"
+version = "3.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/6e/802acd792aebb2256fbbee8cacf2727faaeb6f240ac11008f09eae4414bc/greenlet-3.5.1.tar.gz", hash = "sha256:5a56aeb7d5d9cc4b3a735efb5095bd4b4f6f0e4f93e5ca876d0e2315137b7829", size = 197356, upload-time = "2026-05-20T15:05:03.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/21/117c8710abb7f146d804a124c07eb5964a60b90d02b72452885aecc18efa/greenlet-3.5.1-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:7eacb17a9d41538a2bc4912eba5ef13823c83cb69e4d141d0813debe7163187f", size = 283510, upload-time = "2026-05-20T13:12:26.475Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/f7/6762a56fa5f6c2295c449c6524e10ce481e381c994cc44d9d03aef0700fb/greenlet-3.5.1-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e5cc9606aa5f4e0bde0d3bd502b44f743864c3ffa5cfa1011b1e30f5aa02366f", size = 599696, upload-time = "2026-05-20T14:00:02.906Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/05/85a511e68ee109aff0aa00b4b497806091dd2d82ce209e49c6e801bd5d92/greenlet-3.5.1-cp310-cp310-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c3d35f87c7253b715d13d679e0783d845910144f282cb939fe1ba4ac8616269c", size = 612618, upload-time = "2026-05-20T14:05:39.202Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/19/60df45065b2981ff894fdd51e7c99a3a4b107412822b083d88d5d528f663/greenlet-3.5.1-cp310-cp310-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:00929c98ec525fd9bf075875d8c5f6a983a90906cdf78a66e6de2d8e466c2a19", size = 619237, upload-time = "2026-05-20T14:09:06.421Z" },
+    { url = "https://files.pythonhosted.org/packages/89/b8/8b83d18ae07c46c019617f35afd7b47aab7f9b4fbb12fc637d681e10bdd8/greenlet-3.5.1-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:540dae7b956209af4d70a3be35927b4055f617763771e5e84a5255bea934d2f5", size = 612947, upload-time = "2026-05-20T13:14:23.469Z" },
+    { url = "https://files.pythonhosted.org/packages/26/9a/4ba4c2bc9d9df5f41bb8943fb7bb11e440352e6b9c2e36716b6e85f8b82d/greenlet-3.5.1-cp310-cp310-manylinux_2_39_riscv64.whl", hash = "sha256:001775efe7b8e758861294c7a27c28af87f3f3f1c20468a2bc618c45b346c061", size = 415653, upload-time = "2026-05-20T14:01:36.999Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/14/ad1f9fc9b82384c010212464a3702bd911f95dab2f1180bc6fbcfb1f958c/greenlet-3.5.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:ed8cdb691169715a9a492844a83246f090182247d1a5031dc78a403f68ba1e97", size = 1571425, upload-time = "2026-05-20T14:02:22.671Z" },
+    { url = "https://files.pythonhosted.org/packages/46/1c/43b8203cf10f4292c9e3d270e9e5f5ade79115a0a0ca5ea6f1be5f8915a7/greenlet-3.5.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:9d59e840387076a51016777a9328b3f2c427c6f9208a6e958bad251be50a648d", size = 1638688, upload-time = "2026-05-20T13:14:30.026Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/6e/0344b1e99f58f71715456e46492101fd2daa408957b8186ade0a4b515da7/greenlet-3.5.1-cp310-cp310-win_amd64.whl", hash = "sha256:b9152fca4a6466e114aaec745ae61cba739903a109754a9d4e1262f01e9259b1", size = 237763, upload-time = "2026-05-20T13:11:35.659Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "harvester"
+version = "0.2.0"
+source = { editable = "../harvester" }
+dependencies = [
+    { name = "db-loader" },
+    { name = "diskcache" },
+    { name = "erddapy" },
+    { name = "lxml" },
+    { name = "numpy" },
+    { name = "pandas" },
+    { name = "psycopg2-binary" },
+    { name = "python-dotenv" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "sentry-sdk" },
+    { name = "shapely" },
+    { name = "sqlalchemy" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "db-loader", directory = "../db-loader" },
+    { name = "diskcache", specifier = ">=5.6.3" },
+    { name = "erddapy", specifier = ">=2.2.0" },
+    { name = "lxml", specifier = ">=5.1.0" },
+    { name = "numpy", specifier = "<2.0.0" },
+    { name = "pandas", specifier = "<2.0.0" },
+    { name = "psycopg2-binary", specifier = ">=2.9.9" },
+    { name = "python-dotenv", specifier = ">=1.0.1" },
+    { name = "pyyaml", specifier = ">=6.0.1" },
+    { name = "requests", specifier = ">=2.31.0" },
+    { name = "sentry-sdk", specifier = ">=1.43.0" },
+    { name = "shapely", specifier = ">=2.0.3" },
+    { name = "sqlalchemy", specifier = "<2.0.0" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "lxml"
+version = "6.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/3b/aab6728cae887456f409b4d75e8a01856e4f04bd510de38052a47768b680/lxml-6.1.1.tar.gz", hash = "sha256:ba96ae44888e0185281e937633a743ea90d5a196c6000f82565ebb0580012d40", size = 4197430, upload-time = "2026-05-18T19:19:06.424Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/da/dbe4dfc01ac226fb0504fad035f4d69f3202f3502e20e68537631daddd96/lxml-6.1.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:09dd5b7075dc2f7709654a46543ba1ea3c2e217b2ed8fbd413a8a945a0f40f60", size = 8541124, upload-time = "2026-05-18T19:17:11.589Z" },
+    { url = "https://files.pythonhosted.org/packages/78/20/f7095ed9fc2c025f9cfe71cc6ec9f1feb05624edc1812423b5f1aecf3d4b/lxml-6.1.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:f6ac4ef4d82dff54670227a69c67782ae0b811b5cf6b17954f1e8f7502fc0d1d", size = 4602783, upload-time = "2026-05-18T19:17:20.888Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/a4/65c63ca98bd129f6cff7b8c2fa48953ab058cc6005b541354e7dd54d8000/lxml-6.1.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:556e94a63c9b04716f8e4de2abb65775061f846e89331b6c5be79183a24f98ea", size = 5002687, upload-time = "2026-05-18T19:17:01.738Z" },
+    { url = "https://files.pythonhosted.org/packages/96/1d/ab7a5c4b5a394d98a94e2d0fc67bab8297597426770dd4978370fbdaf531/lxml-6.1.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5c6bf403fbb3b3e348a561a5f4f0b9961835657981c802a1df03653eef8a9074", size = 5155099, upload-time = "2026-05-18T19:17:05.159Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/b1/07603bfeeb891a2596d5c2a68f7d2f70f7d11c841ebe391412c69c2857b0/lxml-6.1.1-cp310-cp310-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1dde6131244bba38a17c745836ba190bc753fd73c9291666287fd0a3fa3dcf30", size = 5057225, upload-time = "2026-05-18T19:17:08.117Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/16/cb391ee4b90186fa16d9ebcbe3ea96c71b8da3b0686386c8dcbcc3c67d44/lxml-6.1.1-cp310-cp310-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:98fc784c2c1440667aeedf8465bdfe10208acf0ead656a2c68627299f546b315", size = 5287643, upload-time = "2026-05-18T19:17:11.507Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/d6/b619717f918fd76747448fdbaee0e769edbc70e659b5b5d0112b7020b7a3/lxml-6.1.1-cp310-cp310-manylinux_2_28_i686.whl", hash = "sha256:add8cf6ddf9a65116119a28ece0f7886e30af27ba724a7594305f1d1b58a92a1", size = 5412445, upload-time = "2026-05-18T19:17:22.182Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/80/12bc5390ac0a3edeb579d9535e5049a5dda663438728e179d52fb319c33a/lxml-6.1.1-cp310-cp310-manylinux_2_31_armv7l.whl", hash = "sha256:cf9d57306d848218f3601fee7601fab1a327c942d56e2e97610583cb4dd74206", size = 4770864, upload-time = "2026-05-18T19:17:26.851Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/59/6500c09da3137f54f020e908d81cfc5ee3e8888e908fd380207afad7c2e6/lxml-6.1.1-cp310-cp310-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:88136950da4d13c318bde414ce10219931937851327f44328f2df4d2c4614067", size = 5359594, upload-time = "2026-05-18T19:17:32.527Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/9b/f64b4cc6b7ebcf75d95af3cde934d254b5f2f10d4163928d838d86b6eb48/lxml-6.1.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:cecdd5dfdc87b1fd87dbf81d4b037a544f47f4c744200a67013771682d67686a", size = 5107713, upload-time = "2026-05-18T19:17:04.402Z" },
+    { url = "https://files.pythonhosted.org/packages/16/19/c7388ad5d3a72315d2832dc1458cbf4f2af7f2b990b606ff4876efd04511/lxml-6.1.1-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:cd312b9692e831d2ffcad61eab31d91d4b4655a962e61de8fb410472cbcd37aa", size = 4803973, upload-time = "2026-05-18T19:17:06.545Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/22/76197f0bbf165f0b9e75be59be4997e5259cde973f12f098c1b54c7f5d60/lxml-6.1.1-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:5b7328b46d49fc9477d91ae8f6d55340347d827b7734ba3ea33faae0efef1383", size = 5349925, upload-time = "2026-05-18T19:17:09.743Z" },
+    { url = "https://files.pythonhosted.org/packages/24/52/d2a0cfeccb9bcdc47c7ee05cdae5d69b48c9acf20997790a6338bb0d0b3b/lxml-6.1.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:37a58976370f36d9329d118ad0b953c5aeb9119ac9c6a4e258942a225d0573a1", size = 5309825, upload-time = "2026-05-18T19:17:13.831Z" },
+    { url = "https://files.pythonhosted.org/packages/19/4a/b30944266776c2f49749ef2445aa7e78898194134b80ad776386f61b56ae/lxml-6.1.1-cp310-cp310-win32.whl", hash = "sha256:cea3f4c1af79af13cdb2da0c028111d8f8522d4f22a000c82385535f24e5cf3a", size = 3598402, upload-time = "2026-05-18T19:17:08.21Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/97/33691c66a4d7ec1a5a98e7c909a5b83ee45c7f7ba4cf92b1c4cf26e98079/lxml-6.1.1-cp310-cp310-win_amd64.whl", hash = "sha256:3abf332af33a74288675d936fe861fd4344da0dd6622193fbc4f2bfbb35536b5", size = 4021295, upload-time = "2026-05-18T19:17:28.638Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/5f/26a4dd0e12b9456ff7b12a21af5b491eb6629680d1edd73f4140fd386bcf/lxml-6.1.1-cp310-cp310-win_arm64.whl", hash = "sha256:8dadbe5b217ff35b6a8d16610dd710219b59b76d13f0e3f0d9f36786206e4485", size = 3667717, upload-time = "2026-05-19T19:22:44.474Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "1.26.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/6e/09db70a523a96d25e115e71cc56a6f9031e7b8cd166c1ac8438307c14058/numpy-1.26.4.tar.gz", hash = "sha256:2a02aba9ed12e4ac4eb3ea9421c420301a0c6460d9830d74a9df87efa4912010", size = 15786129, upload-time = "2024-02-06T00:26:44.495Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/94/ace0fdea5241a27d13543ee117cbc65868e82213fb31a8eb7fe9ff23f313/numpy-1.26.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9ff0f4f29c51e2803569d7a51c2304de5554655a60c5d776e35b4a41413830d0", size = 20631468, upload-time = "2024-02-05T23:48:01.194Z" },
+    { url = "https://files.pythonhosted.org/packages/20/f7/b24208eba89f9d1b58c1668bc6c8c4fd472b20c45573cb767f59d49fb0f6/numpy-1.26.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2e4ee3380d6de9c9ec04745830fd9e2eccb3e6cf790d39d7b98ffd19b0dd754a", size = 13966411, upload-time = "2024-02-05T23:48:29.038Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/a5/4beee6488160798683eed5bdb7eead455892c3b4e1f78d79d8d3f3b084ac/numpy-1.26.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d209d8969599b27ad20994c8e41936ee0964e6da07478d6c35016bc386b66ad4", size = 14219016, upload-time = "2024-02-05T23:48:54.098Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/d7/ecf66c1cd12dc28b4040b15ab4d17b773b87fa9d29ca16125de01adb36cd/numpy-1.26.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ffa75af20b44f8dba823498024771d5ac50620e6915abac414251bd971b4529f", size = 18240889, upload-time = "2024-02-05T23:49:25.361Z" },
+    { url = "https://files.pythonhosted.org/packages/24/03/6f229fe3187546435c4f6f89f6d26c129d4f5bed40552899fcf1f0bf9e50/numpy-1.26.4-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:62b8e4b1e28009ef2846b4c7852046736bab361f7aeadeb6a5b89ebec3c7055a", size = 13876746, upload-time = "2024-02-05T23:49:51.983Z" },
+    { url = "https://files.pythonhosted.org/packages/39/fe/39ada9b094f01f5a35486577c848fe274e374bbf8d8f472e1423a0bbd26d/numpy-1.26.4-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:a4abb4f9001ad2858e7ac189089c42178fcce737e4169dc61321660f1a96c7d2", size = 18078620, upload-time = "2024-02-05T23:50:22.515Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ef/6ad11d51197aad206a9ad2286dc1aac6a378059e06e8cf22cd08ed4f20dc/numpy-1.26.4-cp310-cp310-win32.whl", hash = "sha256:bfe25acf8b437eb2a8b2d49d443800a5f18508cd811fea3181723922a8a82b07", size = 5972659, upload-time = "2024-02-05T23:50:35.834Z" },
+    { url = "https://files.pythonhosted.org/packages/19/77/538f202862b9183f54108557bfda67e17603fc560c384559e769321c9d92/numpy-1.26.4-cp310-cp310-win_amd64.whl", hash = "sha256:b97fe8060236edf3662adfc2c633f56a08ae30560c56310562cb4f95500022d5", size = 15808905, upload-time = "2024-02-05T23:51:03.701Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pandas"
+version = "1.5.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "python-dateutil" },
+    { name = "pytz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/74/ee/146cab1ff6d575b54ace8a6a5994048380dc94879b0125b25e62edcb9e52/pandas-1.5.3.tar.gz", hash = "sha256:74a3fd7e5a7ec052f183273dc7b0acd3a863edf7520f5d3a1765c04ffdb3b0b1", size = 5203060, upload-time = "2023-01-19T08:31:39.615Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/cd/34f6b0780301be81be804d7aa71d571457369e6131e2b330af2b0fed1aad/pandas-1.5.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:3749077d86e3a2f0ed51367f30bf5b82e131cc0f14260c4d3e499186fccc4406", size = 18619230, upload-time = "2023-01-19T08:29:07.301Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/34/b7858bb7d6d6bf4d9df1dde777a11fcf3ff370e1d1b3956e3d0fcca8322c/pandas-1.5.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:972d8a45395f2a2d26733eb8d0f629b2f90bebe8e8eddbb8829b180c09639572", size = 11982991, upload-time = "2023-01-19T08:29:15.383Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/6c/005bd604994f7cbede4d7bf030614ef49a2213f76bc3d738ecf5b0dcc810/pandas-1.5.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:50869a35cbb0f2e0cd5ec04b191e7b12ed688874bd05dd777c19b28cbea90996", size = 10927131, upload-time = "2023-01-19T08:29:20.342Z" },
+    { url = "https://files.pythonhosted.org/packages/27/c7/35b81ce5f680f2dac55eac14d103245cd8cf656ae4a2ff3be2e69fd1d330/pandas-1.5.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c3ac844a0fe00bfaeb2c9b51ab1424e5c8744f89860b138434a363b1f620f354", size = 11368188, upload-time = "2023-01-19T08:29:25.807Z" },
+    { url = "https://files.pythonhosted.org/packages/49/e2/79e46612dc25ebc7603dc11c560baa7266c90f9e48537ecf1a02a0dd6bff/pandas-1.5.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a0a56cef15fd1586726dace5616db75ebcfec9179a3a55e78f72c5639fa2a23", size = 12062104, upload-time = "2023-01-19T08:29:30.695Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/cd/f27c2992cbe05a3e39937f73a4be635a9ec149ec3ca4467d8cf039718994/pandas-1.5.3-cp310-cp310-win_amd64.whl", hash = "sha256:478ff646ca42b20376e4ed3fa2e8d7341e8a63105586efe54fa2508ee087f328", size = 10362473, upload-time = "2023-01-19T08:29:37.506Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "psycopg2-binary"
+version = "2.9.12"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2a/60/a3624f79acea344c16fbef3a94d28b89a8042ddfb8f3e4ca83f538671409/psycopg2_binary-2.9.12.tar.gz", hash = "sha256:5ac9444edc768c02a6b6a591f070b8aae28ff3a99be57560ac996001580f294c", size = 379686, upload-time = "2026-04-21T09:40:34.304Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/80/49bacf9e51617d8309f6f0123e29edc793f6f5f6700c7d1f1b20782fbb37/psycopg2_binary-2.9.12-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9b818ceff717f98851a64bffd4c5eb5b3059ae280276dcecc52ac658dcf006a4", size = 3712314, upload-time = "2026-04-20T23:33:31.363Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/f2/98eeac7d60c43df9338287834edf9b3e69be68a2db78a57b1b81d705e735/psycopg2_binary-2.9.12-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:d2fa0d7caca8635c56e373055094eeda3208d901d55dd0ff5abc1d4e47f82b56", size = 3822389, upload-time = "2026-04-20T23:33:34.178Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/7c/30575e75f14d5351a56a1971bb43fe7f8bf7edf1b654fb1bec65c42a8812/psycopg2_binary-2.9.12-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:864c261b3690e1207d14bbfe0a61e27567981b80c47a778561e49f676f7ce433", size = 4578448, upload-time = "2026-04-20T23:33:37.073Z" },
+    { url = "https://files.pythonhosted.org/packages/65/9b/4df366d89f28c527dc39d0b6c98a5ca74e30d37ac097b73f3352147568ae/psycopg2_binary-2.9.12-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c5ee5213445dd45312459029b8c4c0a695461eb517b753d2582315bd07995f5e", size = 4273705, upload-time = "2026-04-20T23:33:39.291Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/8a/c566803818eb03161ba869b6ba612bf7ad56816d98b9e5121e0a22ad6b0b/psycopg2_binary-2.9.12-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6f9cae1f848779b5b01f417e762c40d026ea93eb0648249a604728cda991dde3", size = 5893784, upload-time = "2026-04-20T23:33:41.658Z" },
+    { url = "https://files.pythonhosted.org/packages/63/fe/0dfa5797e0b229e0567bc378695224caf14d547f73b05be0c80549089772/psycopg2_binary-2.9.12-cp310-cp310-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:63a3ebbd543d3d1eda088ac99164e8c5bac15293ee91f20281fd17d050aee1c4", size = 4109306, upload-time = "2026-04-20T23:33:43.953Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/89/28063adf17a4ba501eedd9890feab0c649ee4d8bd0a97df0ff1e9584feab/psycopg2_binary-2.9.12-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:d6fcbba8c9fed08a73b8ac61ea79e4821e45b1e92bb466230c5e746bbf3d5256", size = 3654400, upload-time = "2026-04-20T23:33:46.115Z" },
+    { url = "https://files.pythonhosted.org/packages/84/94/5a01de0aa4ead0b8d8d1aa4ec18cec0bd36d03fa714eaa5bb8a0b1b50020/psycopg2_binary-2.9.12-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:36512911ebb2b60a0c3e44d0bb5048c1980aced91235d133b7874f3d1d93487c", size = 3299215, upload-time = "2026-04-20T23:33:48.202Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/85/723bb085a61c6ac2dc0a0043f375f2fe7365363e27b073bad56ca5bda979/psycopg2_binary-2.9.12-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:8ffdb59fe88f99589e34354a130217aa1fd2d615612402d6edc8b3dbc7a44463", size = 3047724, upload-time = "2026-04-20T23:33:50.74Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/67/4d8b1e0d2fc4166677380eac0edf9cdff91013aca2546e8ef7bc04b56158/psycopg2_binary-2.9.12-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:a46fe069b65255df410f856d842bc235f90e22ffdf532dda625fd4213d3fd9b1", size = 3349183, upload-time = "2026-04-20T23:33:59.635Z" },
+    { url = "https://files.pythonhosted.org/packages/73/99/21af7a5498637ea4dc91a17c281a53bc1d632fbafe00f6689fbfb32a9fed/psycopg2_binary-2.9.12-cp310-cp310-win_amd64.whl", hash = "sha256:ab29414b25dcb698bf26bf213e3348abdcd07bbd5de032a5bec15bd75b298b03", size = 2757036, upload-time = "2026-04-20T23:34:01.606Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+    { name = "tomli" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-cov"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage", extra = ["toml"] },
+    { name = "pluggy" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "pytest-mock"
+version = "3.15.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/68/14/eb014d26be205d38ad5ad20d9a80f7d201472e08167f0bb4361e251084a9/pytest_mock-3.15.1.tar.gz", hash = "sha256:1849a238f6f396da19762269de72cb1814ab44416fa73a8686deac10b0d87a0f", size = 34036, upload-time = "2025-09-16T16:37:27.081Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/cc/06253936f4a7fa2e0f48dfe6d851d9c56df896a9ab09ac019d70b760619c/pytest_mock-3.15.1-py3-none-any.whl", hash = "sha256:0a25e2eb88fe5168d535041d09a4529a188176ae608a6d249ee65abc0949630d", size = 10095, upload-time = "2025-09-16T16:37:25.734Z" },
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "pytz"
+version = "2026.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ff/46/dd499ec9038423421951e4fad73051febaa13d2df82b4064f87af8b8c0c3/pytz-2026.2.tar.gz", hash = "sha256:0e60b47b29f21574376f218fe21abc009894a2321ea16c6754f3cad6eb7cdd6a", size = 320861, upload-time = "2026-05-04T01:35:29.667Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/dd/96da98f892250475bdf2328112d7468abdd4acc7b902b6af23f4ed958ea0/pytz-2026.2-py2.py3-none-any.whl", hash = "sha256:04156e608bee23d3792fd45c94ae47fae1036688e75032eea2e3bf0323d1f126", size = 510141, upload-time = "2026-05-04T01:35:27.408Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/a0/39350dd17dd6d6c6507025c0e53aef67a9293a6d37d3511f23ea510d5800/pyyaml-6.0.3-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:214ed4befebe12df36bcc8bc2b64b396ca31be9304b8f59e25c11cf94a4c033b", size = 184227, upload-time = "2025-09-25T21:31:46.04Z" },
+    { url = "https://files.pythonhosted.org/packages/05/14/52d505b5c59ce73244f59c7a50ecf47093ce4765f116cdb98286a71eeca2/pyyaml-6.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:02ea2dfa234451bbb8772601d7b8e426c2bfa197136796224e50e35a78777956", size = 174019, upload-time = "2025-09-25T21:31:47.706Z" },
+    { url = "https://files.pythonhosted.org/packages/43/f7/0e6a5ae5599c838c696adb4e6330a59f463265bfa1e116cfd1fbb0abaaae/pyyaml-6.0.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b30236e45cf30d2b8e7b3e85881719e98507abed1011bf463a8fa23e9c3e98a8", size = 740646, upload-time = "2025-09-25T21:31:49.21Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/3a/61b9db1d28f00f8fd0ae760459a5c4bf1b941baf714e207b6eb0657d2578/pyyaml-6.0.3-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:66291b10affd76d76f54fad28e22e51719ef9ba22b29e1d7d03d6777a9174198", size = 840793, upload-time = "2025-09-25T21:31:50.735Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1e/7acc4f0e74c4b3d9531e24739e0ab832a5edf40e64fbae1a9c01941cabd7/pyyaml-6.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9c7708761fccb9397fe64bbc0395abcae8c4bf7b0eac081e12b809bf47700d0b", size = 770293, upload-time = "2025-09-25T21:31:51.828Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/ef/abd085f06853af0cd59fa5f913d61a8eab65d7639ff2a658d18a25d6a89d/pyyaml-6.0.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:418cf3f2111bc80e0933b2cd8cd04f286338bb88bdc7bc8e6dd775ebde60b5e0", size = 732872, upload-time = "2025-09-25T21:31:53.282Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/15/2bc9c8faf6450a8b3c9fc5448ed869c599c0a74ba2669772b1f3a0040180/pyyaml-6.0.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:5e0b74767e5f8c593e8c9b5912019159ed0533c70051e9cce3e8b6aa699fcd69", size = 758828, upload-time = "2025-09-25T21:31:54.807Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/00/531e92e88c00f4333ce359e50c19b8d1de9fe8d581b1534e35ccfbc5f393/pyyaml-6.0.3-cp310-cp310-win32.whl", hash = "sha256:28c8d926f98f432f88adc23edf2e6d4921ac26fb084b028c733d01868d19007e", size = 142415, upload-time = "2025-09-25T21:31:55.885Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/fa/926c003379b19fca39dd4634818b00dec6c62d87faf628d1394e137354d4/pyyaml-6.0.3-cp310-cp310-win_amd64.whl", hash = "sha256:bdb2c67c6c1390b63c6ff89f210c8fd09d9a1217a465701eac7316313c915e4c", size = 158561, upload-time = "2025-09-25T21:31:57.406Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.34.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
+]
+
+[[package]]
+name = "sentry-sdk"
+version = "2.61.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/63/3b/4bc6b348bbd331daa14d4babe9f2b99bc854f4da41560eefb9488d78481d/sentry_sdk-2.61.1.tar.gz", hash = "sha256:9c6adccb3feefa9ba032c8d295ca477575c2f11896046a2b0ad686c47c4af555", size = 459429, upload-time = "2026-06-01T07:24:18.875Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/54/c9218db183846e08efaf68534889ef42e499dde432778881104a42f7071b/sentry_sdk-2.61.1-py3-none-any.whl", hash = "sha256:fa36eaf4b8ad708f718500d4bdcc1532637526a22beb874d88cbc0a46458b5ae", size = 483735, upload-time = "2026-06-01T07:24:17.027Z" },
+]
+
+[[package]]
+name = "shapely"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4d/bc/0989043118a27cccb4e906a46b7565ce36ca7b57f5a18b78f4f1b0f72d9d/shapely-2.1.2.tar.gz", hash = "sha256:2ed4ecb28320a433db18a5bf029986aa8afcfd740745e78847e330d5d94922a9", size = 315489, upload-time = "2025-09-24T13:51:41.432Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/89/c3548aa9b9812a5d143986764dededfa48d817714e947398bdda87c77a72/shapely-2.1.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:7ae48c236c0324b4e139bea88a306a04ca630f49be66741b340729d380d8f52f", size = 1825959, upload-time = "2025-09-24T13:50:00.682Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/8a/7ebc947080442edd614ceebe0ce2cdbd00c25e832c240e1d1de61d0e6b38/shapely-2.1.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:eba6710407f1daa8e7602c347dfc94adc02205ec27ed956346190d66579eb9ea", size = 1629196, upload-time = "2025-09-24T13:50:03.447Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/86/c9c27881c20d00fc409e7e059de569d5ed0abfcec9c49548b124ebddea51/shapely-2.1.2-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ef4a456cc8b7b3d50ccec29642aa4aeda959e9da2fe9540a92754770d5f0cf1f", size = 2951065, upload-time = "2025-09-24T13:50:05.266Z" },
+    { url = "https://files.pythonhosted.org/packages/50/8a/0ab1f7433a2a85d9e9aea5b1fbb333f3b09b309e7817309250b4b7b2cc7a/shapely-2.1.2-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e38a190442aacc67ff9f75ce60aec04893041f16f97d242209106d502486a142", size = 3058666, upload-time = "2025-09-24T13:50:06.872Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/c6/5a30ffac9c4f3ffd5b7113a7f5299ccec4713acd5ee44039778a7698224e/shapely-2.1.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:40d784101f5d06a1fd30b55fc11ea58a61be23f930d934d86f19a180909908a4", size = 3966905, upload-time = "2025-09-24T13:50:09.417Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/72/e92f3035ba43e53959007f928315a68fbcf2eeb4e5ededb6f0dc7ff1ecc3/shapely-2.1.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:f6f6cd5819c50d9bcf921882784586aab34a4bd53e7553e175dece6db513a6f0", size = 4129260, upload-time = "2025-09-24T13:50:11.183Z" },
+    { url = "https://files.pythonhosted.org/packages/42/24/605901b73a3d9f65fa958e63c9211f4be23d584da8a1a7487382fac7fdc5/shapely-2.1.2-cp310-cp310-win32.whl", hash = "sha256:fe9627c39c59e553c90f5bc3128252cb85dc3b3be8189710666d2f8bc3a5503e", size = 1544301, upload-time = "2025-09-24T13:50:12.521Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/89/6db795b8dd3919851856bd2ddd13ce434a748072f6fdee42ff30cbd3afa3/shapely-2.1.2-cp310-cp310-win_amd64.whl", hash = "sha256:1d0bfb4b8f661b3b4ec3565fa36c340bfb1cda82087199711f86a88647d26b2f", size = 1722074, upload-time = "2025-09-24T13:50:13.909Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "sqlalchemy"
+version = "1.4.54"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet", marker = "platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ce/af/20290b55d469e873cba9d41c0206ab5461ff49d759989b3fe65010f9d265/sqlalchemy-1.4.54.tar.gz", hash = "sha256:4470fbed088c35dc20b78a39aaf4ae54fe81790c783b3264872a0224f437c31a", size = 8470350, upload-time = "2024-09-05T15:54:10.398Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/7f/f7c1e0b65790649bd573f201aa958263a389f336d6e000a569275ff9bd97/SQLAlchemy-1.4.54-cp310-cp310-macosx_12_0_x86_64.whl", hash = "sha256:af00236fe21c4d4f4c227b6ccc19b44c594160cc3ff28d104cdce85855369277", size = 1573472, upload-time = "2024-09-05T17:38:45.351Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/da/ff7f0fe50844496db523613979651f076f44da8625b8ad89c503dcff0a52/SQLAlchemy-1.4.54-cp310-cp310-manylinux1_x86_64.manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_5_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1183599e25fa38a1a322294b949da02b4f0da13dbc2688ef9dbe746df573f8a6", size = 1639088, upload-time = "2024-09-05T17:46:37.726Z" },
+    { url = "https://files.pythonhosted.org/packages/04/45/3a35bb156aa2fd87b66a4992bb8d65593efd7e16ca2e0597e68c32c29037/SQLAlchemy-1.4.54-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1990d5a6a5dc358a0894c8ca02043fb9a5ad9538422001fb2826e91c50f1d539", size = 1627447, upload-time = "2024-09-05T17:45:32.379Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/5b/ed36a50e7147d0d090cd8e35de3b18d2c69a3e85df3be5fe42a570d6c331/SQLAlchemy-1.4.54-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:14b3f4783275339170984cadda66e3ec011cce87b405968dc8d51cf0f9997b0d", size = 1639081, upload-time = "2024-09-05T17:46:39.895Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/75/bfbdeb5dece7bc98acb414751a62ee43398b34b10133b1853f4282597757/SQLAlchemy-1.4.54-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6b24364150738ce488333b3fb48bfa14c189a66de41cd632796fbcacb26b4585", size = 1638975, upload-time = "2024-09-05T17:46:41.569Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/62/358a9291d2fc3d51ad50557e126ad5f48200f199878437f7cb38817d607b/SQLAlchemy-1.4.54-cp310-cp310-win32.whl", hash = "sha256:a8a72259a1652f192c68377be7011eac3c463e9892ef2948828c7d58e4829988", size = 1591719, upload-time = "2024-09-05T17:52:26.646Z" },
+    { url = "https://files.pythonhosted.org/packages/10/ad/87cd5578efdcef43a08ce4a21448192abf46bf69a5678ac0039e44364914/SQLAlchemy-1.4.54-cp310-cp310-win_amd64.whl", hash = "sha256:b67589f7955924865344e6eacfdcf70675e64f36800a576aa5e961f0008cde2a", size = 1593512, upload-time = "2024-09-05T17:51:21.402Z" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f", size = 17543, upload-time = "2026-03-25T20:22:03.828Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]

--- a/tests/validation_reports/20260602_164156/events.jsonl
+++ b/tests/validation_reports/20260602_164156/events.jsonl
@@ -1,0 +1,3 @@
+{"time": "2026-06-02T16:41:56", "level": "INFO", "logger": "cde_harvester.harvest_erddap", "message": "No skipped datasets list found", "exc_info": null}
+{"time": "2026-06-02T16:41:56", "level": "INFO", "logger": "mock.erddap.local", "message": "Fetching all datasets from ERDDAP server: https://mock.erddap.local/erddap", "exc_info": null}
+{"time": "2026-06-02T16:41:56", "level": "INFO", "logger": "mock.erddap.local", "message": "Requesting: https://mock.erddap.local/erddap/tabledap/allDatasets.csv?&accessible=\"public\"&dataStructure=\"table\"", "exc_info": null}

--- a/tests/validation_reports/20260602_164156/report.json
+++ b/tests/validation_reports/20260602_164156/report.json
@@ -1,0 +1,80 @@
+{
+  "run_id": "20260602_164156",
+  "start_time": "2026-06-02T16:41:56.188043",
+  "end_time": "2026-06-02T16:41:56.336321",
+  "duration_s": 0.148278,
+  "duration_human": "0s",
+  "config_summary": {
+    "erddap_server_count": 1,
+    "erddap_urls": [
+      "https://mock.erddap.local/erddap"
+    ],
+    "dataset_id_filter": [],
+    "cache_enabled": true,
+    "max_workers": 1
+  },
+  "findings": [
+    {
+      "severity": "CRITICAL",
+      "category": "Server Unreachable",
+      "title": "All 1 request(s) to mock.erddap.local failed",
+      "detail": "First error: _mock_get() takes 1 positional argument but 2 were given. Server may be down or URL incorrect.",
+      "affected": [
+        "mock.erddap.local"
+      ],
+      "count": 1
+    },
+    {
+      "severity": "CRITICAL",
+      "category": "Empty Output",
+      "title": "No datasets were harvested \u2014 output is completely empty",
+      "detail": "datasets DataFrame is empty despite no fatal error. Possible causes: all servers unreachable, all datasets skipped, or misconfigured erddap_urls in config.",
+      "affected": [],
+      "count": 0
+    },
+    {
+      "severity": "HIGH",
+      "category": "HTTP Error",
+      "title": "1 HTTP request(s) returned status connection_error",
+      "detail": "First affected URLs:\n  https://mock.erddap.local/erddap/tabledap/allDatasets.csv?&accessible=\"public\"&dataStructure=\"table\"",
+      "affected": [
+        "https://mock.erddap.local/erddap/tabledap/allDatasets.csv?&accessible=\"public\"&dataStructure=\"table\""
+      ],
+      "count": 1
+    }
+  ],
+  "skip_breakdown": [],
+  "http_summary": {
+    "total": 1,
+    "success": 0,
+    "errors": 1,
+    "redirects": 0,
+    "avg_elapsed_s": 0.0,
+    "max_elapsed_s": 0.0,
+    "total_mb": 0.0,
+    "errors_by_status": {
+      "connection_error": 1
+    },
+    "servers_contacted": [
+      "mock.erddap.local"
+    ]
+  },
+  "log_summary": {
+    "INFO": 3,
+    "DEBUG": 0,
+    "WARNING": 0,
+    "ERROR": 0,
+    "CRITICAL": 0
+  },
+  "data_summary": {
+    "servers_configured": 1,
+    "servers_with_results": 0,
+    "datasets_harvested": 0,
+    "datasets_skipped": 0,
+    "datasets_total": 0,
+    "profiles_extracted": 0,
+    "unique_erddap_servers_in_output": 0
+  },
+  "per_server_summary": {},
+  "error_log_lines": []
+}

--- a/tests/validation_reports/20260602_164156/report.md
+++ b/tests/validation_reports/20260602_164156/report.md
@@ -1,0 +1,87 @@
+# Harvest Validation Report
+
+**Run ID:** `20260602_164156`  
+**Started:** 2026-06-02T16:41:56.188043  
+**Ended:**   2026-06-02T16:41:56.336321  
+**Duration:** 0s  
+**ERDDAP servers configured:** 1  
+**Dataset ID filter active:** No  
+**Cache enabled:** True
+
+## Executive Summary
+
+| Metric | Value |
+|--------|-------|
+| Servers configured | 1 |
+| Servers with results | 0 |
+| Datasets discovered | 0 |
+| Datasets harvested | 0 (N/A) |
+| Datasets skipped | 0 |
+| Profiles extracted | 0 |
+| HTTP calls | 1 |
+| HTTP errors | 1 (100.0%) |
+| Run duration | 0s |
+
+**Findings:** [CRITICAL]: 2  [HIGH]: 1  [MEDIUM]: 0  [LOW]: 0  [INFO]: 0
+
+## Findings
+
+### CRITICAL (2)
+
+**[Server Unreachable]** All 1 request(s) to mock.erddap.local failed
+> First error: _mock_get() takes 1 positional argument but 2 were given. Server may be down or URL incorrect.
+Affected: `mock.erddap.local`
+
+**[Empty Output]** No datasets were harvested — output is completely empty
+> datasets DataFrame is empty despite no fatal error. Possible causes: all servers unreachable, all datasets skipped, or misconfigured erddap_urls in config.
+
+### HIGH (1)
+
+**[HTTP Error]** 1 HTTP request(s) returned status connection_error
+> First affected URLs:
+  https://mock.erddap.local/erddap/tabledap/allDatasets.csv?&accessible="public"&dataStructure="table"
+Affected: `https://mock.erddap.local/erddap/tabledap/allDatasets.csv?&accessible="public"&dataStructure="table"`
+
+### MEDIUM (0)
+
+*(none)*
+### LOW (0)
+
+*(none)*
+### INFO (0)
+
+*(none)*
+
+## Skip Analysis
+
+No datasets were skipped.
+
+## HTTP API Calls
+
+- **Total:** 1
+- **Success (200):** 0 (0.0%)
+- **Errors:** 1 (100.0%)
+- **Redirects (EDDTableFromErddap):** 0
+- **Avg response time:** 0.00s
+- **Max response time:** 0.00s
+- **Total data transferred:** 0.0 MB
+
+**Error breakdown by status:**
+  - HTTP connection_error: 1
+
+**Servers contacted:**
+  - `mock.erddap.local`
+
+## Log Event Summary
+
+| Level | Count |
+|-------|-------|
+| DEBUG | 0 |
+| INFO | 3 |
+| WARNING | 0 |
+| ERROR | 0 |
+| CRITICAL | 0 |
+
+## Error Log Entries
+
+*(no ERROR or CRITICAL events)*

--- a/tests/validation_reports/20260602_164345/events.jsonl
+++ b/tests/validation_reports/20260602_164345/events.jsonl
@@ -1,0 +1,4 @@
+{"time": "2026-06-02T16:43:45", "level": "INFO", "logger": "cde_harvester.harvest_erddap", "message": "No skipped datasets list found", "exc_info": null}
+{"time": "2026-06-02T16:43:45", "level": "INFO", "logger": "mock.erddap.local", "message": "Fetching all datasets from ERDDAP server: https://mock.erddap.local/erddap", "exc_info": null}
+{"time": "2026-06-02T16:43:45", "level": "INFO", "logger": "mock.erddap.local", "message": "Requesting: https://mock.erddap.local/erddap/tabledap/allDatasets.csv?&accessible=\"public\"&dataStructure=\"table\"", "exc_info": null}
+{"time": "2026-06-02T16:43:45", "level": "INFO", "logger": "mock.erddap.local", "message": "Found 0 datasets", "exc_info": null}

--- a/tests/validation_reports/20260602_164345/report.json
+++ b/tests/validation_reports/20260602_164345/report.json
@@ -1,0 +1,58 @@
+{
+  "run_id": "20260602_164345",
+  "start_time": "2026-06-02T16:43:45.077199",
+  "end_time": "2026-06-02T16:43:45.181721",
+  "duration_s": 0.104522,
+  "duration_human": "0s",
+  "config_summary": {
+    "erddap_server_count": 1,
+    "erddap_urls": [
+      "https://mock.erddap.local/erddap"
+    ],
+    "dataset_id_filter": [],
+    "cache_enabled": false,
+    "max_workers": 1
+  },
+  "findings": [
+    {
+      "severity": "CRITICAL",
+      "category": "Empty Output",
+      "title": "No datasets were harvested \u2014 output is completely empty",
+      "detail": "datasets DataFrame is empty despite no fatal error. Possible causes: all servers unreachable, all datasets skipped, or misconfigured erddap_urls in config.",
+      "affected": [],
+      "count": 0
+    }
+  ],
+  "skip_breakdown": [],
+  "http_summary": {
+    "total": 1,
+    "success": 1,
+    "errors": 0,
+    "redirects": 0,
+    "avg_elapsed_s": 0.0,
+    "max_elapsed_s": 0.0,
+    "total_mb": 0.0,
+    "errors_by_status": {},
+    "servers_contacted": [
+      "mock.erddap.local"
+    ]
+  },
+  "log_summary": {
+    "INFO": 4,
+    "DEBUG": 0,
+    "WARNING": 0,
+    "ERROR": 0,
+    "CRITICAL": 0
+  },
+  "data_summary": {
+    "servers_configured": 1,
+    "servers_with_results": 0,
+    "datasets_harvested": 0,
+    "datasets_skipped": 0,
+    "datasets_total": 0,
+    "profiles_extracted": 0,
+    "unique_erddap_servers_in_output": 0
+  },
+  "per_server_summary": {},
+  "error_log_lines": []
+}

--- a/tests/validation_reports/20260602_164345/report.md
+++ b/tests/validation_reports/20260602_164345/report.md
@@ -1,0 +1,76 @@
+# Harvest Validation Report
+
+**Run ID:** `20260602_164345`  
+**Started:** 2026-06-02T16:43:45.077199  
+**Ended:**   2026-06-02T16:43:45.181721  
+**Duration:** 0s  
+**ERDDAP servers configured:** 1  
+**Dataset ID filter active:** No  
+**Cache enabled:** False
+
+## Executive Summary
+
+| Metric | Value |
+|--------|-------|
+| Servers configured | 1 |
+| Servers with results | 0 |
+| Datasets discovered | 0 |
+| Datasets harvested | 0 (N/A) |
+| Datasets skipped | 0 |
+| Profiles extracted | 0 |
+| HTTP calls | 1 |
+| HTTP errors | 0 (0.0%) |
+| Run duration | 0s |
+
+**Findings:** [CRITICAL]: 1  [HIGH]: 0  [MEDIUM]: 0  [LOW]: 0  [INFO]: 0
+
+## Findings
+
+### CRITICAL (1)
+
+**[Empty Output]** No datasets were harvested — output is completely empty
+> datasets DataFrame is empty despite no fatal error. Possible causes: all servers unreachable, all datasets skipped, or misconfigured erddap_urls in config.
+
+### HIGH (0)
+
+*(none)*
+### MEDIUM (0)
+
+*(none)*
+### LOW (0)
+
+*(none)*
+### INFO (0)
+
+*(none)*
+
+## Skip Analysis
+
+No datasets were skipped.
+
+## HTTP API Calls
+
+- **Total:** 1
+- **Success (200):** 1 (100.0%)
+- **Errors:** 0 (0.0%)
+- **Redirects (EDDTableFromErddap):** 0
+- **Avg response time:** 0.00s
+- **Max response time:** 0.00s
+- **Total data transferred:** 0.0 MB
+
+**Servers contacted:**
+  - `mock.erddap.local`
+
+## Log Event Summary
+
+| Level | Count |
+|-------|-------|
+| DEBUG | 0 |
+| INFO | 4 |
+| WARNING | 0 |
+| ERROR | 0 |
+| CRITICAL | 0 |
+
+## Error Log Entries
+
+*(no ERROR or CRITICAL events)*

--- a/tests/validation_reports/20260602_164813/events.jsonl
+++ b/tests/validation_reports/20260602_164813/events.jsonl
@@ -1,0 +1,4 @@
+{"time": "2026-06-02T16:48:13", "level": "INFO", "logger": "cde_harvester.harvest_erddap", "message": "No skipped datasets list found", "exc_info": null}
+{"time": "2026-06-02T16:48:13", "level": "INFO", "logger": "mock.erddap.local", "message": "Fetching all datasets from ERDDAP server: https://mock.erddap.local/erddap", "exc_info": null}
+{"time": "2026-06-02T16:48:13", "level": "INFO", "logger": "mock.erddap.local", "message": "Requesting: https://mock.erddap.local/erddap/tabledap/allDatasets.csv?&accessible=\"public\"&dataStructure=\"table\"", "exc_info": null}
+{"time": "2026-06-02T16:48:13", "level": "INFO", "logger": "mock.erddap.local", "message": "Found 0 datasets", "exc_info": null}

--- a/tests/validation_reports/20260602_164813/report.json
+++ b/tests/validation_reports/20260602_164813/report.json
@@ -1,0 +1,58 @@
+{
+  "run_id": "20260602_164813",
+  "start_time": "2026-06-02T16:48:13.287744",
+  "end_time": "2026-06-02T16:48:13.392345",
+  "duration_s": 0.104601,
+  "duration_human": "0s",
+  "config_summary": {
+    "erddap_server_count": 1,
+    "erddap_urls": [
+      "https://mock.erddap.local/erddap"
+    ],
+    "dataset_id_filter": [],
+    "cache_enabled": false,
+    "max_workers": 1
+  },
+  "findings": [
+    {
+      "severity": "CRITICAL",
+      "category": "Empty Output",
+      "title": "No datasets were harvested \u2014 output is completely empty",
+      "detail": "datasets DataFrame is empty despite no fatal error. Possible causes: all servers unreachable, all datasets skipped, or misconfigured erddap_urls in config.",
+      "affected": [],
+      "count": 0
+    }
+  ],
+  "skip_breakdown": [],
+  "http_summary": {
+    "total": 1,
+    "success": 1,
+    "errors": 0,
+    "redirects": 0,
+    "avg_elapsed_s": 0.0,
+    "max_elapsed_s": 0.0,
+    "total_mb": 0.0,
+    "errors_by_status": {},
+    "servers_contacted": [
+      "mock.erddap.local"
+    ]
+  },
+  "log_summary": {
+    "INFO": 4,
+    "DEBUG": 0,
+    "WARNING": 0,
+    "ERROR": 0,
+    "CRITICAL": 0
+  },
+  "data_summary": {
+    "servers_configured": 1,
+    "servers_with_results": 0,
+    "datasets_harvested": 0,
+    "datasets_skipped": 0,
+    "datasets_total": 0,
+    "profiles_extracted": 0,
+    "unique_erddap_servers_in_output": 0
+  },
+  "per_server_summary": {},
+  "error_log_lines": []
+}

--- a/tests/validation_reports/20260602_164813/report.md
+++ b/tests/validation_reports/20260602_164813/report.md
@@ -1,0 +1,76 @@
+# Harvest Validation Report
+
+**Run ID:** `20260602_164813`  
+**Started:** 2026-06-02T16:48:13.287744  
+**Ended:**   2026-06-02T16:48:13.392345  
+**Duration:** 0s  
+**ERDDAP servers configured:** 1  
+**Dataset ID filter active:** No  
+**Cache enabled:** False
+
+## Executive Summary
+
+| Metric | Value |
+|--------|-------|
+| Servers configured | 1 |
+| Servers with results | 0 |
+| Datasets discovered | 0 |
+| Datasets harvested | 0 (N/A) |
+| Datasets skipped | 0 |
+| Profiles extracted | 0 |
+| HTTP calls | 1 |
+| HTTP errors | 0 (0.0%) |
+| Run duration | 0s |
+
+**Findings:** [CRITICAL]: 1  [HIGH]: 0  [MEDIUM]: 0  [LOW]: 0  [INFO]: 0
+
+## Findings
+
+### CRITICAL (1)
+
+**[Empty Output]** No datasets were harvested — output is completely empty
+> datasets DataFrame is empty despite no fatal error. Possible causes: all servers unreachable, all datasets skipped, or misconfigured erddap_urls in config.
+
+### HIGH (0)
+
+*(none)*
+### MEDIUM (0)
+
+*(none)*
+### LOW (0)
+
+*(none)*
+### INFO (0)
+
+*(none)*
+
+## Skip Analysis
+
+No datasets were skipped.
+
+## HTTP API Calls
+
+- **Total:** 1
+- **Success (200):** 1 (100.0%)
+- **Errors:** 0 (0.0%)
+- **Redirects (EDDTableFromErddap):** 0
+- **Avg response time:** 0.00s
+- **Max response time:** 0.00s
+- **Total data transferred:** 0.0 MB
+
+**Servers contacted:**
+  - `mock.erddap.local`
+
+## Log Event Summary
+
+| Level | Count |
+|-------|-------|
+| DEBUG | 0 |
+| INFO | 4 |
+| WARNING | 0 |
+| ERROR | 0 |
+| CRITICAL | 0 |
+
+## Error Log Entries
+
+*(no ERROR or CRITICAL events)*

--- a/uv.lock
+++ b/uv.lock
@@ -95,6 +95,15 @@ wheels = [
 ]
 
 [[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
 name = "db-loader"
 version = "0.1.0"
 source = { directory = "db-loader" }
@@ -134,6 +143,7 @@ dependencies = [
     { name = "downloader" },
     { name = "harvester" },
     { name = "jinja2" },
+    { name = "loguru" },
     { name = "psycopg2-binary" },
     { name = "python-dotenv" },
     { name = "sentry-sdk" },
@@ -145,6 +155,7 @@ requires-dist = [
     { name = "downloader", directory = "downloader" },
     { name = "harvester", directory = "harvester" },
     { name = "jinja2", specifier = ">=3.1.6" },
+    { name = "loguru", specifier = ">=0.7.3" },
     { name = "psycopg2-binary", specifier = ">=2.9.10" },
     { name = "python-dotenv", specifier = ">=1.1.1" },
     { name = "sentry-sdk", specifier = ">=2.38.0" },
@@ -157,6 +168,8 @@ version = "0.1.0"
 source = { directory = "downloader" }
 dependencies = [
     { name = "erddapy" },
+    { name = "loguru" },
+    { name = "numpy" },
     { name = "pandas" },
     { name = "pdfkit" },
     { name = "sentry-sdk" },
@@ -166,10 +179,18 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "erddapy", specifier = ">=2.2.4" },
+    { name = "loguru", specifier = ">=0.7.3" },
+    { name = "numpy", specifier = "<2.0.0" },
     { name = "pandas", specifier = "<2.0.0" },
     { name = "pdfkit", specifier = ">=1.0.0" },
     { name = "sentry-sdk", specifier = ">=2.38.0" },
     { name = "shapely", specifier = ">=2.1.1" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "harvester", directory = "harvester" },
+    { name = "pytest", specifier = ">=8.4.2" },
 ]
 
 [[package]]
@@ -227,6 +248,8 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7f/91/ae2eb6b7979e2f9b035a9f612cf70f1bf54aad4e1d125129bef1eae96f19/greenlet-3.2.4-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c2ca18a03a8cfb5b25bc1cbe20f3d9a4c80d8c3b13ba3df49ac3961af0b1018d", size = 584358, upload-time = "2025-08-07T13:18:23.708Z" },
     { url = "https://files.pythonhosted.org/packages/f7/85/433de0c9c0252b22b16d413c9407e6cb3b41df7389afc366ca204dbc1393/greenlet-3.2.4-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:9fe0a28a7b952a21e2c062cd5756d34354117796c6d9215a87f55e38d15402c5", size = 1113550, upload-time = "2025-08-07T13:42:37.467Z" },
     { url = "https://files.pythonhosted.org/packages/a1/8d/88f3ebd2bc96bf7747093696f4335a0a8a4c5acfcf1b757717c0d2474ba3/greenlet-3.2.4-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:8854167e06950ca75b898b104b63cc646573aa5fef1353d4508ecdd1ee76254f", size = 1137126, upload-time = "2025-08-07T13:18:20.239Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/29/74242b7d72385e29bcc5563fba67dad94943d7cd03552bac320d597f29b2/greenlet-3.2.4-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:f47617f698838ba98f4ff4189aef02e7343952df3a615f847bb575c3feb177a7", size = 1544904, upload-time = "2025-11-04T12:42:04.763Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/e2/1572b8eeab0f77df5f6729d6ab6b141e4a84ee8eb9bc8c1e7918f94eda6d/greenlet-3.2.4-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:af41be48a4f60429d5cad9d22175217805098a9ef7c40bfef44f7669fb9d74d8", size = 1611228, upload-time = "2025-11-04T12:42:08.423Z" },
     { url = "https://files.pythonhosted.org/packages/d6/6f/b60b0291d9623c496638c582297ead61f43c4b72eef5e9c926ef4565ec13/greenlet-3.2.4-cp310-cp310-win_amd64.whl", hash = "sha256:73f49b5368b5359d04e18d15828eecc1806033db5233397748f4ca813ff1056c", size = 298654, upload-time = "2025-08-07T13:50:00.469Z" },
     { url = "https://files.pythonhosted.org/packages/a4/de/f28ced0a67749cac23fecb02b694f6473f47686dff6afaa211d186e2ef9c/greenlet-3.2.4-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:96378df1de302bc38e99c3a9aa311967b7dc80ced1dcc6f171e99842987882a2", size = 272305, upload-time = "2025-08-07T13:15:41.288Z" },
     { url = "https://files.pythonhosted.org/packages/09/16/2c3792cba130000bf2a31c5272999113f4764fd9d874fb257ff588ac779a/greenlet-3.2.4-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1ee8fae0519a337f2329cb78bd7a8e128ec0f881073d43f023c7b8d4831d5246", size = 632472, upload-time = "2025-08-07T13:42:55.044Z" },
@@ -236,6 +259,8 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/8e/abdd3f14d735b2929290a018ecf133c901be4874b858dd1c604b9319f064/greenlet-3.2.4-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2523e5246274f54fdadbce8494458a2ebdcdbc7b802318466ac5606d3cded1f8", size = 587684, upload-time = "2025-08-07T13:18:25.164Z" },
     { url = "https://files.pythonhosted.org/packages/5d/65/deb2a69c3e5996439b0176f6651e0052542bb6c8f8ec2e3fba97c9768805/greenlet-3.2.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:1987de92fec508535687fb807a5cea1560f6196285a4cde35c100b8cd632cc52", size = 1116647, upload-time = "2025-08-07T13:42:38.655Z" },
     { url = "https://files.pythonhosted.org/packages/3f/cc/b07000438a29ac5cfb2194bfc128151d52f333cee74dd7dfe3fb733fc16c/greenlet-3.2.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:55e9c5affaa6775e2c6b67659f3a71684de4c549b3dd9afca3bc773533d284fa", size = 1142073, upload-time = "2025-08-07T13:18:21.737Z" },
+    { url = "https://files.pythonhosted.org/packages/67/24/28a5b2fa42d12b3d7e5614145f0bd89714c34c08be6aabe39c14dd52db34/greenlet-3.2.4-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c9c6de1940a7d828635fbd254d69db79e54619f165ee7ce32fda763a9cb6a58c", size = 1548385, upload-time = "2025-11-04T12:42:11.067Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/05/03f2f0bdd0b0ff9a4f7b99333d57b53a7709c27723ec8123056b084e69cd/greenlet-3.2.4-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:03c5136e7be905045160b1b9fdca93dd6727b180feeafda6818e6496434ed8c5", size = 1613329, upload-time = "2025-11-04T12:42:12.928Z" },
     { url = "https://files.pythonhosted.org/packages/d8/0f/30aef242fcab550b0b3520b8e3561156857c94288f0332a79928c31a52cf/greenlet-3.2.4-cp311-cp311-win_amd64.whl", hash = "sha256:9c40adce87eaa9ddb593ccb0fa6a07caf34015a29bf8d344811665b573138db9", size = 299100, upload-time = "2025-08-07T13:44:12.287Z" },
     { url = "https://files.pythonhosted.org/packages/44/69/9b804adb5fd0671f367781560eb5eb586c4d495277c93bde4307b9e28068/greenlet-3.2.4-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:3b67ca49f54cede0186854a008109d6ee71f66bd57bb36abd6d0a0267b540cdd", size = 274079, upload-time = "2025-08-07T13:15:45.033Z" },
     { url = "https://files.pythonhosted.org/packages/46/e9/d2a80c99f19a153eff70bc451ab78615583b8dac0754cfb942223d2c1a0d/greenlet-3.2.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ddf9164e7a5b08e9d22511526865780a576f19ddd00d62f8a665949327fde8bb", size = 640997, upload-time = "2025-08-07T13:42:56.234Z" },
@@ -245,6 +270,8 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/19/0d/6660d55f7373b2ff8152401a83e02084956da23ae58cddbfb0b330978fe9/greenlet-3.2.4-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3b3812d8d0c9579967815af437d96623f45c0f2ae5f04e366de62a12d83a8fb0", size = 607586, upload-time = "2025-08-07T13:18:28.544Z" },
     { url = "https://files.pythonhosted.org/packages/8e/1a/c953fdedd22d81ee4629afbb38d2f9d71e37d23caace44775a3a969147d4/greenlet-3.2.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:abbf57b5a870d30c4675928c37278493044d7c14378350b3aa5d484fa65575f0", size = 1123281, upload-time = "2025-08-07T13:42:39.858Z" },
     { url = "https://files.pythonhosted.org/packages/3f/c7/12381b18e21aef2c6bd3a636da1088b888b97b7a0362fac2e4de92405f97/greenlet-3.2.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:20fb936b4652b6e307b8f347665e2c615540d4b42b3b4c8a321d8286da7e520f", size = 1151142, upload-time = "2025-08-07T13:18:22.981Z" },
+    { url = "https://files.pythonhosted.org/packages/27/45/80935968b53cfd3f33cf99ea5f08227f2646e044568c9b1555b58ffd61c2/greenlet-3.2.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ee7a6ec486883397d70eec05059353b8e83eca9168b9f3f9a361971e77e0bcd0", size = 1564846, upload-time = "2025-11-04T12:42:15.191Z" },
+    { url = "https://files.pythonhosted.org/packages/69/02/b7c30e5e04752cb4db6202a3858b149c0710e5453b71a3b2aec5d78a1aab/greenlet-3.2.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:326d234cbf337c9c3def0676412eb7040a35a768efc92504b947b3e9cfc7543d", size = 1633814, upload-time = "2025-11-04T12:42:17.175Z" },
     { url = "https://files.pythonhosted.org/packages/e9/08/b0814846b79399e585f974bbeebf5580fbe59e258ea7be64d9dfb253c84f/greenlet-3.2.4-cp312-cp312-win_amd64.whl", hash = "sha256:a7d4e128405eea3814a12cc2605e0e6aedb4035bf32697f72deca74de4105e02", size = 299899, upload-time = "2025-08-07T13:38:53.448Z" },
     { url = "https://files.pythonhosted.org/packages/49/e8/58c7f85958bda41dafea50497cbd59738c5c43dbbea5ee83d651234398f4/greenlet-3.2.4-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:1a921e542453fe531144e91e1feedf12e07351b1cf6c9e8a3325ea600a715a31", size = 272814, upload-time = "2025-08-07T13:15:50.011Z" },
     { url = "https://files.pythonhosted.org/packages/62/dd/b9f59862e9e257a16e4e610480cfffd29e3fae018a68c2332090b53aac3d/greenlet-3.2.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cd3c8e693bff0fff6ba55f140bf390fa92c994083f838fece0f63be121334945", size = 641073, upload-time = "2025-08-07T13:42:57.23Z" },
@@ -254,6 +281,8 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ee/43/3cecdc0349359e1a527cbf2e3e28e5f8f06d3343aaf82ca13437a9aa290f/greenlet-3.2.4-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:23768528f2911bcd7e475210822ffb5254ed10d71f4028387e5a99b4c6699671", size = 610497, upload-time = "2025-08-07T13:18:31.636Z" },
     { url = "https://files.pythonhosted.org/packages/b8/19/06b6cf5d604e2c382a6f31cafafd6f33d5dea706f4db7bdab184bad2b21d/greenlet-3.2.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:00fadb3fedccc447f517ee0d3fd8fe49eae949e1cd0f6a611818f4f6fb7dc83b", size = 1121662, upload-time = "2025-08-07T13:42:41.117Z" },
     { url = "https://files.pythonhosted.org/packages/a2/15/0d5e4e1a66fab130d98168fe984c509249c833c1a3c16806b90f253ce7b9/greenlet-3.2.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:d25c5091190f2dc0eaa3f950252122edbbadbb682aa7b1ef2f8af0f8c0afefae", size = 1149210, upload-time = "2025-08-07T13:18:24.072Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/53/f9c440463b3057485b8594d7a638bed53ba531165ef0ca0e6c364b5cc807/greenlet-3.2.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:6e343822feb58ac4d0a1211bd9399de2b3a04963ddeec21530fc426cc121f19b", size = 1564759, upload-time = "2025-11-04T12:42:19.395Z" },
+    { url = "https://files.pythonhosted.org/packages/47/e4/3bb4240abdd0a8d23f4f88adec746a3099f0d86bfedb623f063b2e3b4df0/greenlet-3.2.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ca7f6f1f2649b89ce02f6f229d7c19f680a6238af656f61e0115b24857917929", size = 1634288, upload-time = "2025-11-04T12:42:21.174Z" },
     { url = "https://files.pythonhosted.org/packages/0b/55/2321e43595e6801e105fcfdee02b34c0f996eb71e6ddffca6b10b7e1d771/greenlet-3.2.4-cp313-cp313-win_amd64.whl", hash = "sha256:554b03b6e73aaabec3745364d6239e9e012d64c68ccd0b8430c64ccc14939a8b", size = 299685, upload-time = "2025-08-07T13:24:38.824Z" },
     { url = "https://files.pythonhosted.org/packages/22/5c/85273fd7cc388285632b0498dbbab97596e04b154933dfe0f3e68156c68c/greenlet-3.2.4-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:49a30d5fda2507ae77be16479bdb62a660fa51b1eb4928b524975b3bde77b3c0", size = 273586, upload-time = "2025-08-07T13:16:08.004Z" },
     { url = "https://files.pythonhosted.org/packages/d1/75/10aeeaa3da9332c2e761e4c50d4c3556c21113ee3f0afa2cf5769946f7a3/greenlet-3.2.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:299fd615cd8fc86267b47597123e3f43ad79c9d8a22bebdce535e53550763e2f", size = 686346, upload-time = "2025-08-07T13:42:59.944Z" },
@@ -261,6 +290,8 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/8b/29aae55436521f1d6f8ff4e12fb676f3400de7fcf27fccd1d4d17fd8fecd/greenlet-3.2.4-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b4a1870c51720687af7fa3e7cda6d08d801dae660f75a76f3845b642b4da6ee1", size = 694659, upload-time = "2025-08-07T13:53:17.759Z" },
     { url = "https://files.pythonhosted.org/packages/92/2e/ea25914b1ebfde93b6fc4ff46d6864564fba59024e928bdc7de475affc25/greenlet-3.2.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:061dc4cf2c34852b052a8620d40f36324554bc192be474b9e9770e8c042fd735", size = 695355, upload-time = "2025-08-07T13:18:34.517Z" },
     { url = "https://files.pythonhosted.org/packages/72/60/fc56c62046ec17f6b0d3060564562c64c862948c9d4bc8aa807cf5bd74f4/greenlet-3.2.4-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:44358b9bf66c8576a9f57a590d5f5d6e72fa4228b763d0e43fee6d3b06d3a337", size = 657512, upload-time = "2025-08-07T13:18:33.969Z" },
+    { url = "https://files.pythonhosted.org/packages/23/6e/74407aed965a4ab6ddd93a7ded3180b730d281c77b765788419484cdfeef/greenlet-3.2.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:2917bdf657f5859fbf3386b12d68ede4cf1f04c90c3a6bc1f013dd68a22e2269", size = 1612508, upload-time = "2025-11-04T12:42:23.427Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/da/343cd760ab2f92bac1845ca07ee3faea9fe52bee65f7bcb19f16ad7de08b/greenlet-3.2.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:015d48959d4add5d6c9f6c5210ee3803a830dce46356e3bc326d6776bde54681", size = 1680760, upload-time = "2025-11-04T12:42:25.341Z" },
     { url = "https://files.pythonhosted.org/packages/e3/a5/6ddab2b4c112be95601c13428db1d8b6608a8b6039816f2ba09c346c08fc/greenlet-3.2.4-cp314-cp314-win_amd64.whl", hash = "sha256:e37ab26028f12dbb0ff65f29a8d3d44a765c61e729647bf2ddfbbed621726f01", size = 303425, upload-time = "2025-08-07T13:32:27.59Z" },
 ]
 
@@ -357,6 +388,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "loguru"
+version = "0.7.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "win32-setctime", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3a/05/a1dae3dffd1116099471c643b8924f5aa6524411dc6c63fdae648c4f1aca/loguru-0.7.3.tar.gz", hash = "sha256:19480589e77d47b8d85b2c827ad95d49bf31b0dcde16593892eb51dd18706eb6", size = 63559, upload-time = "2024-12-06T11:20:56.608Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/29/0348de65b8cc732daa3e33e67806420b2ae89bdce2b04af740289c5c6c8c/loguru-0.7.3-py3-none-any.whl", hash = "sha256:31a33c10c8e1e10422bfd431aeb5d351c7cf7fa671e3c4df004162264b28220c", size = 61595, upload-time = "2024-12-06T11:20:54.538Z" },
 ]
 
 [[package]]
@@ -893,4 +937,13 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/15/22/9ee70a2574a4f4599c47dd506532914ce044817c7752a79b6a51286319bc/urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760", size = 393185, upload-time = "2025-06-18T14:07:41.644Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/c2/fe1e52489ae3122415c51f387e221dd0773709bad6c6cdaa599e8a2c5185/urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc", size = 129795, upload-time = "2025-06-18T14:07:40.39Z" },
+]
+
+[[package]]
+name = "win32-setctime"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b3/8f/705086c9d734d3b663af0e9bb3d4de6578d08f46b1b101c2442fd9aecaa2/win32_setctime-1.2.0.tar.gz", hash = "sha256:ae1fdf948f5640aae05c511ade119313fb6a30d7eabe25fef9764dca5873c4c0", size = 4867, upload-time = "2024-12-07T15:28:28.314Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/07/c6fe3ad3e685340704d314d765b7912993bcb8dc198f0e7a89382d37974b/win32_setctime-1.2.0-py3-none-any.whl", hash = "sha256:95d644c4e708aba81dc3704a116d8cbc974d70b3bdb8be1d150e36be6e9d1390", size = 4083, upload-time = "2024-12-07T15:28:26.465Z" },
 ]

--- a/web-api/__tests__/helpers/mockDb.js
+++ b/web-api/__tests__/helpers/mockDb.js
@@ -1,0 +1,77 @@
+/**
+ * Factory helpers for mocking the Knex database client.
+ *
+ * Two shapes are needed:
+ *   - db.raw(sql, params)  → resolves to { rows: [...] }
+ *   - db("table")          → thenable chainable query builder
+ *
+ * Knex Raw objects also expose:
+ *   - .sql         (the SQL string)
+ *   - .toSQL()     (returns { sql, bindings })
+ * Both are used by dbFilter.js and legend.js.
+ */
+
+/**
+ * Build a mock for db.raw(sql, params).
+ * Returns an object that is both awaitable and carries the Knex Raw metadata
+ * that the application code inspects (.sql, .toSQL).
+ */
+function buildRawMock(rows = [], sql = 'SELECT 1') {
+  return {
+    rows,          // direct rows property (used by shapeQuery: rows.rows)
+    sql,           // .sql property checked by shapeQuery.js
+    toSQL: jest.fn(() => ({ sql, bindings: [] })),
+    then: (onFulfilled, onRejected) =>
+      Promise.resolve({ rows }).then(onFulfilled, onRejected),
+    catch: (onRejected) =>
+      Promise.resolve({ rows }).catch(onRejected),
+    toString: () => sql,
+  };
+}
+
+/**
+ * Build a mock for db("table") — a chainable, thenable query builder.
+ * Every chaining method returns `this` so multi-call chains work.
+ * When awaited, resolves to `rows`.
+ */
+function buildQueryBuilderMock(rows = []) {
+  const qb = {
+    select: jest.fn().mockReturnThis(),
+    where: jest.fn().mockReturnThis(),
+    orderBy: jest.fn().mockReturnThis(),
+    orderByRaw: jest.fn().mockReturnThis(),
+    join: jest.fn().mockReturnThis(),
+    insert: jest.fn().mockResolvedValue([1]),
+    then: (onFulfilled, onRejected) =>
+      Promise.resolve(rows).then(onFulfilled, onRejected),
+    catch: (onRejected) =>
+      Promise.resolve(rows).catch(onRejected),
+  };
+  return qb;
+}
+
+/**
+ * Create a complete db mock.
+ *
+ * Usage in test files:
+ *   jest.mock('../../db');
+ *   const db = require('../../db');
+ *   const { setRawRows, setTableRows } = setupDbMock(db);
+ *   setRawRows([{ platform: 'buoy' }]);
+ */
+function setupDbMock(mockDb) {
+  let rawRows = [];
+  let tableRows = [];
+
+  const rawMock = jest.fn((sql = 'SELECT 1') => buildRawMock(rawRows, sql));
+  mockDb.mockImplementation(() => buildQueryBuilderMock(tableRows));
+  mockDb.raw = rawMock;
+
+  return {
+    setRawRows: (rows) => { rawRows = rows; },
+    setTableRows: (rows) => { tableRows = rows; },
+    getRawMock: () => rawMock,
+  };
+}
+
+module.exports = { buildRawMock, buildQueryBuilderMock, setupDbMock };

--- a/web-api/__tests__/routes/datasetRecordsList.test.js
+++ b/web-api/__tests__/routes/datasetRecordsList.test.js
@@ -1,0 +1,67 @@
+/**
+ * GET /datasetRecordsList
+ *
+ * Requires query param `datasetPKs` (integer).
+ * Returns a single dataset object with profile list.
+ * Uses datasetDetailsMiddleware() which validates datasetPKs is an integer.
+ */
+
+jest.mock('../../db');
+jest.mock('../../utils/cache', () => ({ route: () => (_req, _res, next) => next() }));
+jest.mock('../../utils/redis', () => ({ connect: jest.fn().mockRejectedValue(new Error('no redis')) }));
+jest.mock('../../utils/shapeQuery');
+
+const request = require('supertest');
+const app = require('../../app');
+const { getShapeQuery } = require('../../utils/shapeQuery');
+
+const RECORD_DETAILS = {
+  pk: 'ds-1',
+  pk_url: 'ds-1',
+  dataset_id: 'test_ds_001',
+  title: 'Test Dataset',
+  profiles: [
+    { profile_id: 'PROF-1', time_min: '2020-01-01', time_max: '2022-12-31', depth_min: 0, depth_max: 200 },
+  ],
+};
+
+beforeEach(() => getShapeQuery.mockResolvedValue([RECORD_DETAILS]));
+afterEach(() => jest.clearAllMocks());
+
+describe('GET /datasetRecordsList', () => {
+  it('returns 200 with a valid integer datasetPKs', async () => {
+    const res = await request(app).get('/datasetRecordsList?datasetPKs=42');
+    expect(res.status).toBe(200);
+  });
+
+  it('returns the single dataset object (pop of results array)', async () => {
+    const res = await request(app).get('/datasetRecordsList?datasetPKs=42');
+    expect(res.body).toHaveProperty('dataset_id', 'test_ds_001');
+  });
+
+  it('returns 400 when datasetPKs is missing', async () => {
+    const res = await request(app).get('/datasetRecordsList');
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when datasetPKs is not an integer', async () => {
+    const res = await request(app).get('/datasetRecordsList?datasetPKs=abc');
+    expect(res.status).toBe(400);
+  });
+
+  it('calls getShapeQuery with getRecordsList=true', async () => {
+    await request(app).get('/datasetRecordsList?datasetPKs=42');
+    expect(getShapeQuery).toHaveBeenCalledWith(
+      expect.any(Object),
+      false,
+      true,
+    );
+  });
+
+  it('passes timeMin filter alongside datasetPKs', async () => {
+    await request(app).get('/datasetRecordsList?datasetPKs=42&timeMin=2021-01-01T00:00:00Z');
+    const [query] = getShapeQuery.mock.calls[0];
+    expect(query.timeMin).toBe('2021-01-01T00:00:00Z');
+    expect(query.datasetPKs).toBe('42');
+  });
+});

--- a/web-api/__tests__/routes/datasets.test.js
+++ b/web-api/__tests__/routes/datasets.test.js
@@ -1,0 +1,73 @@
+/**
+ * GET /datasets
+ *
+ * Returns all datasets with title, pk, organization_pks, platform,
+ * and title_translated (en/fr object) via a db.raw() SELECT.
+ */
+
+jest.mock('../../db');
+jest.mock('../../utils/cache', () => ({ route: () => (_req, _res, next) => next() }));
+jest.mock('../../utils/redis', () => ({ connect: jest.fn().mockRejectedValue(new Error('no redis')) }));
+
+const request = require('supertest');
+const app = require('../../app');
+const db = require('../../db');
+const { setupDbMock } = require('../helpers/mockDb');
+
+const { setRawRows } = setupDbMock(db);
+
+const DATASETS = [
+  {
+    title: 'Ocean Temperature Survey',
+    pk: 'pk-1',
+    pk_url: 'pk-1',
+    organization_pks: [1, 2],
+    platform: 'buoy',
+    title_translated: { en: 'Ocean Temperature Survey', fr: 'Relevé de température océanique' },
+  },
+  {
+    title: 'Salinity Monitoring',
+    pk: 'pk-2',
+    pk_url: 'pk-2',
+    organization_pks: [3],
+    platform: 'ship',
+    title_translated: { en: 'Salinity Monitoring', fr: 'Surveillance de la salinité' },
+  },
+];
+
+beforeEach(() => setRawRows(DATASETS));
+
+describe('GET /datasets', () => {
+  it('returns 200', async () => {
+    const res = await request(app).get('/datasets');
+    expect(res.status).toBe(200);
+  });
+
+  it('returns an array', async () => {
+    const res = await request(app).get('/datasets');
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body).toHaveLength(2);
+  });
+
+  it('each row has required fields', async () => {
+    const res = await request(app).get('/datasets');
+    const [first] = res.body;
+    expect(first).toHaveProperty('title');
+    expect(first).toHaveProperty('organization_pks');
+    expect(first).toHaveProperty('platform');
+    expect(first).toHaveProperty('title_translated');
+  });
+
+  it('title_translated is an object with en and fr keys', async () => {
+    const res = await request(app).get('/datasets');
+    const { title_translated } = res.body[0];
+    expect(title_translated).toHaveProperty('en');
+    expect(title_translated).toHaveProperty('fr');
+  });
+
+  it('returns empty array when no datasets', async () => {
+    setRawRows([]);
+    const res = await request(app).get('/datasets');
+    expect(res.body).toEqual([]);
+  });
+});

--- a/web-api/__tests__/routes/download.test.js
+++ b/web-api/__tests__/routes/download.test.js
@@ -1,0 +1,141 @@
+/**
+ * GET /download
+ *
+ * Creates a download job when datasets are found for the given filters.
+ * Validation via requiredShapeMiddleware (shape checks) and express-validator (email).
+ *
+ * NOTE: The email check (`check("email").isEmail()`) in the route registers a
+ * validator but the async handler never calls validationResult(), so invalid
+ * email addresses are NOT rejected at the HTTP layer — this is a known source-code
+ * gap documented in docs/technical_debt.md.  Tests below assert actual behaviour.
+ *
+ * Shape validation rejects partial bounding boxes (some but not all of
+ * latMin/latMax/lonMin/lonMax supplied).
+ */
+
+jest.mock('../../db');
+jest.mock('../../utils/cache', () => ({ route: () => (_req, _res, next) => next() }));
+jest.mock('../../utils/redis', () => ({ connect: jest.fn().mockRejectedValue(new Error('no redis')) }));
+jest.mock('../../utils/shapeQuery');
+
+// dbFilter returns a mock Raw object that serialises cleanly in template literals
+jest.mock('../../utils/dbFilter', () =>
+  jest.fn(() => ({
+    sql: 'TRUE',
+    toString: () => 'TRUE',
+    toSQL: jest.fn(() => ({ sql: 'TRUE', bindings: [] })),
+  })),
+);
+
+const request = require('supertest');
+const app = require('../../app');
+const db = require('../../db');
+const { getShapeQuery } = require('../../utils/shapeQuery');
+const { setupDbMock } = require('../helpers/mockDb');
+
+const { setRawRows } = setupDbMock(db);
+
+// Simulate a successful db.raw response with two matching datasets
+const MATCHING_DATASETS = [
+  {
+    erddap_url: 'https://erddap.example.com/erddap',
+    dataset_id: 'test_ds_001',
+    title: 'Test Dataset',
+    profile_variables: ['station_id'],
+    cdm_data_type: 'TimeSeries',
+    ckan_id: 'ckan-uuid-1',
+  },
+];
+
+const BASE_QUERY = {
+  email: 'user@example.com',
+  latMin: '45',
+  latMax: '55',
+  lonMin: '-130',
+  lonMax: '-120',
+};
+
+beforeEach(() => {
+  setRawRows([{ json_agg: MATCHING_DATASETS }]);
+  getShapeQuery.mockResolvedValue([{ pk_url: 'ds-1', dataset_id: 'test_ds_001', size: 1000 }]);
+});
+
+afterEach(() => jest.clearAllMocks());
+
+describe('GET /download — happy path', () => {
+  it('returns 200 when datasets are found', async () => {
+    const res = await request(app).get('/download').query(BASE_QUERY);
+    expect(res.status).toBe(200);
+  });
+
+  it('returns { count: N } matching the number of datasets', async () => {
+    const res = await request(app).get('/download').query(BASE_QUERY);
+    expect(res.body).toHaveProperty('count', 1);
+  });
+
+  it('inserts a row into cde.download_jobs', async () => {
+    await request(app).get('/download').query(BASE_QUERY);
+    const qb = db.mock.results.find((r) => r.value?.insert);
+    expect(qb?.value?.insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        email: 'user@example.com',
+        downloader_input: expect.any(Object),
+      }),
+    );
+  });
+
+  it('does not insert a download job when no datasets match', async () => {
+    // json_agg=null means the SELECT found no matching profiles/datasets.
+    // The job should NOT be queued.
+    // Note: `count` in download.js is an implicit global (undeclared variable),
+    // so its value when json_agg is null depends on prior calls in the same
+    // process — this is a known tech-debt item. We assert the observable
+    // side-effect (no DB insert) rather than the stale count value.
+    setRawRows([{ json_agg: null }]);
+    const insertMock = jest.fn().mockResolvedValue([1]);
+    db.mockReturnValue({ insert: insertMock, orderByRaw: jest.fn().mockReturnThis() });
+
+    const res = await request(app).get('/download').query(BASE_QUERY);
+    expect(res.status).toBe(200);
+    expect(insertMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('GET /download — shape validation', () => {
+  it('returns 400 when only latMin is provided (partial bounding box)', async () => {
+    const res = await request(app)
+      .get('/download')
+      .query({ email: 'user@example.com', latMin: '45' });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for partial bounding box with three of four coords', async () => {
+    const res = await request(app)
+      .get('/download')
+      .query({ email: 'user@example.com', latMin: '45', latMax: '55', lonMin: '-130' }); // missing lonMax
+    expect(res.status).toBe(400);
+  });
+
+  it('accepts request with no shape (all filters optional)', async () => {
+    // shape validation passes when neither polygon nor lat/lon bounds are given
+    const res = await request(app).get('/download').query({ email: 'user@example.com' });
+    expect(res.status).toBe(200);
+  });
+
+  it('accepts a valid polygon', async () => {
+    const polygon = JSON.stringify([[-130, 45], [-120, 45], [-120, 55], [-130, 55], [-130, 45]]);
+    const res = await request(app)
+      .get('/download')
+      .query({ email: 'user@example.com', polygon });
+    expect(res.status).toBe(200);
+  });
+});
+
+describe('GET /download — error handling', () => {
+  it('returns 404 with error message when db.raw throws', async () => {
+    db.raw = jest.fn().mockRejectedValue(new Error('DB connection lost'));
+    const res = await request(app).get('/download').query(BASE_QUERY);
+    expect(res.status).toBe(404);
+    expect(res.body).toHaveProperty('error');
+  });
+});

--- a/web-api/__tests__/routes/downloadEstimate.test.js
+++ b/web-api/__tests__/routes/downloadEstimate.test.js
@@ -1,0 +1,68 @@
+/**
+ * GET /downloadEstimate
+ *
+ * No required parameters. Delegates to getShapeQuery(req.query, doEstimate=true).
+ * Returns [{ pk, dataset_id, size }] for each matching dataset.
+ */
+
+jest.mock('../../db');
+jest.mock('../../utils/cache', () => ({ route: () => (_req, _res, next) => next() }));
+jest.mock('../../utils/redis', () => ({ connect: jest.fn().mockRejectedValue(new Error('no redis')) }));
+jest.mock('../../utils/shapeQuery');
+
+const request = require('supertest');
+const app = require('../../app');
+const { getShapeQuery } = require('../../utils/shapeQuery');
+
+const ESTIMATE_RESULT = [
+  { pk_url: 'ds-1', dataset_id: 'test_ds_001', size: 1048576, title: 'Test Dataset' },
+  { pk_url: 'ds-2', dataset_id: 'test_ds_002', size: 2097152, title: 'Another Dataset' },
+];
+
+beforeEach(() => getShapeQuery.mockResolvedValue(ESTIMATE_RESULT));
+afterEach(() => jest.clearAllMocks());
+
+describe('GET /downloadEstimate', () => {
+  it('returns 200', async () => {
+    const res = await request(app).get('/downloadEstimate');
+    expect(res.status).toBe(200);
+  });
+
+  it('returns an array', async () => {
+    const res = await request(app).get('/downloadEstimate');
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body).toHaveLength(2);
+  });
+
+  it('maps pk_url → pk, keeps dataset_id and size', async () => {
+    const res = await request(app).get('/downloadEstimate');
+    const [first] = res.body;
+    expect(first.pk).toBe('ds-1');
+    expect(first.dataset_id).toBe('test_ds_001');
+    expect(first.size).toBe(1048576);
+    // title is not part of the exposed shape
+    expect(first).not.toHaveProperty('pk_url');
+  });
+
+  it('calls getShapeQuery with doEstimate=true', async () => {
+    await request(app).get('/downloadEstimate');
+    expect(getShapeQuery).toHaveBeenCalledWith(
+      expect.any(Object),
+      true,
+      false,
+    );
+  });
+
+  it('passes filter params to getShapeQuery', async () => {
+    await request(app).get('/downloadEstimate?datasetPKs=1,2&timeMin=2020-01-01T00:00:00Z');
+    const [query] = getShapeQuery.mock.calls[0];
+    expect(query.datasetPKs).toBe('1,2');
+    expect(query.timeMin).toBe('2020-01-01T00:00:00Z');
+  });
+
+  it('returns empty array when no matching datasets', async () => {
+    getShapeQuery.mockResolvedValue([]);
+    const res = await request(app).get('/downloadEstimate');
+    expect(res.body).toEqual([]);
+  });
+});

--- a/web-api/__tests__/routes/legend.test.js
+++ b/web-api/__tests__/routes/legend.test.js
@@ -1,0 +1,65 @@
+/**
+ * GET /legend
+ *
+ * Returns { recordsCount: { zoom0, zoom1, zoom2 } } for map legend rendering.
+ * Accepts optional filter params (timeMin, timeMax, etc.).
+ * Uses validatorMiddleware() so invalid filter params return 400.
+ *
+ * db.raw() is mocked; the SQL template is never executed.
+ */
+
+jest.mock('../../db');
+jest.mock('../../utils/cache', () => ({ route: () => (_req, _res, next) => next() }));
+jest.mock('../../utils/redis', () => ({ connect: jest.fn().mockRejectedValue(new Error('no redis')) }));
+
+const request = require('supertest');
+const app = require('../../app');
+const db = require('../../db');
+const { setupDbMock } = require('../helpers/mockDb');
+
+const { setRawRows } = setupDbMock(db);
+
+const LEGEND_ROW = { zoom0: [1, 42], zoom1: [1, 105], zoom2: [1, 350] };
+
+beforeEach(() => setRawRows([LEGEND_ROW]));
+afterEach(() => jest.clearAllMocks());
+
+describe('GET /legend', () => {
+  it('returns 200', async () => {
+    const res = await request(app).get('/legend');
+    expect(res.status).toBe(200);
+  });
+
+  it('returns recordsCount with zoom0, zoom1, zoom2', async () => {
+    const res = await request(app).get('/legend');
+    expect(res.body).toHaveProperty('recordsCount');
+    const { recordsCount } = res.body;
+    expect(recordsCount).toHaveProperty('zoom0');
+    expect(recordsCount).toHaveProperty('zoom1');
+    expect(recordsCount).toHaveProperty('zoom2');
+  });
+
+  it('each zoom level is an array of two numbers', async () => {
+    const res = await request(app).get('/legend');
+    const { recordsCount } = res.body;
+    ['zoom0', 'zoom1', 'zoom2'].forEach((z) => {
+      expect(Array.isArray(recordsCount[z])).toBe(true);
+      expect(recordsCount[z]).toHaveLength(2);
+    });
+  });
+
+  it('passes timeMin filter through without error', async () => {
+    const res = await request(app).get('/legend?timeMin=2020-01-01T00:00:00Z');
+    expect(res.status).toBe(200);
+  });
+
+  it('rejects invalid timeMin with 400', async () => {
+    const res = await request(app).get('/legend?timeMin=not-a-date');
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects non-integer depthMin with 400', async () => {
+    const res = await request(app).get('/legend?depthMin=abc');
+    expect(res.status).toBe(400);
+  });
+});

--- a/web-api/__tests__/routes/oceanVariables.test.js
+++ b/web-api/__tests__/routes/oceanVariables.test.js
@@ -1,0 +1,51 @@
+/**
+ * GET /oceanVariables
+ *
+ * Returns an array of distinct ocean variable name strings
+ * by unnesting the eovs array column across all datasets.
+ */
+
+jest.mock('../../db');
+jest.mock('../../utils/cache', () => ({ route: () => (_req, _res, next) => next() }));
+jest.mock('../../utils/redis', () => ({ connect: jest.fn().mockRejectedValue(new Error('no redis')) }));
+
+const request = require('supertest');
+const app = require('../../app');
+const db = require('../../db');
+const { setupDbMock } = require('../helpers/mockDb');
+
+const { setRawRows } = setupDbMock(db);
+
+const EOV_ROWS = [
+  { ocean_variables: 'seaSurfaceTemperature' },
+  { ocean_variables: 'salinity' },
+  { ocean_variables: 'oxygen' },
+];
+
+beforeEach(() => setRawRows(EOV_ROWS));
+
+describe('GET /oceanVariables', () => {
+  it('returns 200', async () => {
+    const res = await request(app).get('/oceanVariables');
+    expect(res.status).toBe(200);
+  });
+
+  it('returns an array of strings', async () => {
+    const res = await request(app).get('/oceanVariables');
+    expect(Array.isArray(res.body)).toBe(true);
+    res.body.forEach((v) => expect(typeof v).toBe('string'));
+  });
+
+  it('extracts the ocean_variables field from each row', async () => {
+    const res = await request(app).get('/oceanVariables');
+    expect(res.body).toContain('seaSurfaceTemperature');
+    expect(res.body).toContain('salinity');
+    expect(res.body).toContain('oxygen');
+  });
+
+  it('returns empty array when no EOVs exist', async () => {
+    setRawRows([]);
+    const res = await request(app).get('/oceanVariables');
+    expect(res.body).toEqual([]);
+  });
+});

--- a/web-api/__tests__/routes/organizations.test.js
+++ b/web-api/__tests__/routes/organizations.test.js
@@ -1,0 +1,59 @@
+/**
+ * GET /organizations
+ *
+ * Returns every organization ordered by name (case-insensitive).
+ * Uses db("cde.organizations").orderByRaw("UPPER(name)") — the chainable Knex API.
+ * changePKtoPkURL maps pk_url → pk on each row.
+ */
+
+jest.mock('../../db');
+jest.mock('../../utils/cache', () => ({ route: () => (_req, _res, next) => next() }));
+jest.mock('../../utils/redis', () => ({ connect: jest.fn().mockRejectedValue(new Error('no redis')) }));
+
+const request = require('supertest');
+const app = require('../../app');
+const db = require('../../db');
+const { setupDbMock } = require('../helpers/mockDb');
+
+const { setTableRows } = setupDbMock(db);
+
+const ORGS = [
+  { pk_url: 'abc123', name: 'CIOOS Pacific' },
+  { pk_url: 'def456', name: 'CIOOS Atlantic' },
+];
+
+beforeEach(() => setTableRows(ORGS));
+
+describe('GET /organizations', () => {
+  it('returns 200 with an array', async () => {
+    const res = await request(app).get('/organizations');
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+  });
+
+  it('maps pk_url to pk on each row', async () => {
+    const res = await request(app).get('/organizations');
+    expect(res.body[0].pk).toBe('abc123');
+    expect(res.body[1].pk).toBe('def456');
+  });
+
+  it('preserves name field', async () => {
+    const res = await request(app).get('/organizations');
+    const names = res.body.map((o) => o.name);
+    expect(names).toContain('CIOOS Pacific');
+    expect(names).toContain('CIOOS Atlantic');
+  });
+
+  it('calls orderByRaw for case-insensitive sorting', async () => {
+    await request(app).get('/organizations');
+    const qb = db.mock.results[0].value;
+    expect(qb.orderByRaw).toHaveBeenCalledWith('UPPER(name)');
+  });
+
+  it('returns empty array when no organizations exist', async () => {
+    setTableRows([]);
+    const res = await request(app).get('/organizations');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([]);
+  });
+});

--- a/web-api/__tests__/routes/platforms.test.js
+++ b/web-api/__tests__/routes/platforms.test.js
@@ -1,0 +1,45 @@
+/**
+ * GET /platforms
+ *
+ * Returns an array of distinct platform name strings from cde.datasets.
+ * NULL platforms are excluded by the WHERE clause in the SQL.
+ */
+
+jest.mock('../../db');
+jest.mock('../../utils/cache', () => ({ route: () => (_req, _res, next) => next() }));
+jest.mock('../../utils/redis', () => ({ connect: jest.fn().mockRejectedValue(new Error('no redis')) }));
+
+const request = require('supertest');
+const app = require('../../app');
+const db = require('../../db');
+const { setupDbMock } = require('../helpers/mockDb');
+
+const { setRawRows } = setupDbMock(db);
+
+beforeEach(() => setRawRows([{ platform: 'buoy' }, { platform: 'ship' }, { platform: 'mooring' }]));
+
+describe('GET /platforms', () => {
+  it('returns 200', async () => {
+    const res = await request(app).get('/platforms');
+    expect(res.status).toBe(200);
+  });
+
+  it('returns an array of strings', async () => {
+    const res = await request(app).get('/platforms');
+    expect(Array.isArray(res.body)).toBe(true);
+    res.body.forEach((p) => expect(typeof p).toBe('string'));
+  });
+
+  it('extracts the platform field from each row', async () => {
+    const res = await request(app).get('/platforms');
+    expect(res.body).toContain('buoy');
+    expect(res.body).toContain('ship');
+    expect(res.body).toContain('mooring');
+  });
+
+  it('returns empty array when no platforms exist', async () => {
+    setRawRows([]);
+    const res = await request(app).get('/platforms');
+    expect(res.body).toEqual([]);
+  });
+});

--- a/web-api/__tests__/routes/pointQuery.test.js
+++ b/web-api/__tests__/routes/pointQuery.test.js
@@ -1,0 +1,61 @@
+/**
+ * GET /pointQuery
+ *
+ * Delegates to getShapeQuery(req.query, doEstimate=false, getRecordsList=false).
+ * No required parameters — filters are optional.
+ */
+
+jest.mock('../../db');
+jest.mock('../../utils/cache', () => ({ route: () => (_req, _res, next) => next() }));
+jest.mock('../../utils/redis', () => ({ connect: jest.fn().mockRejectedValue(new Error('no redis')) }));
+jest.mock('../../utils/shapeQuery');
+
+const request = require('supertest');
+const app = require('../../app');
+const { getShapeQuery } = require('../../utils/shapeQuery');
+
+const QUERY_RESULT = [
+  { pk: 'ds-1', dataset_id: 'test_ds_001', title: 'Test Dataset', eovs: ['seaSurfaceTemperature'], platform: 'buoy' },
+  { pk: 'ds-2', dataset_id: 'test_ds_002', title: 'Another Dataset', eovs: ['salinity'], platform: 'ship' },
+];
+
+beforeEach(() => {
+  getShapeQuery.mockResolvedValue(QUERY_RESULT);
+});
+
+afterEach(() => jest.clearAllMocks());
+
+describe('GET /pointQuery', () => {
+  it('returns 200', async () => {
+    const res = await request(app).get('/pointQuery');
+    expect(res.status).toBe(200);
+  });
+
+  it('returns the array from getShapeQuery', async () => {
+    const res = await request(app).get('/pointQuery');
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body).toHaveLength(2);
+  });
+
+  it('calls getShapeQuery with doEstimate=false', async () => {
+    await request(app).get('/pointQuery');
+    expect(getShapeQuery).toHaveBeenCalledWith(
+      expect.any(Object),
+      false,
+      false,
+    );
+  });
+
+  it('passes query params to getShapeQuery', async () => {
+    await request(app).get('/pointQuery?timeMin=2020-01-01T00:00:00Z&eovs=salinity');
+    const [query] = getShapeQuery.mock.calls[0];
+    expect(query.timeMin).toBe('2020-01-01T00:00:00Z');
+    expect(query.eovs).toBe('salinity');
+  });
+
+  it('returns empty array when no datasets match', async () => {
+    getShapeQuery.mockResolvedValue([]);
+    const res = await request(app).get('/pointQuery');
+    expect(res.body).toEqual([]);
+  });
+});

--- a/web-api/__tests__/setup.js
+++ b/web-api/__tests__/setup.js
@@ -1,0 +1,15 @@
+/**
+ * Jest global setup — sets env vars before any module is required.
+ * This prevents db.js from attempting a real PostgreSQL connection
+ * and keeps tests fully offline.
+ */
+process.env.DB_USER = 'testuser';
+process.env.DB_PASSWORD = 'testpass';
+process.env.DB_HOST = 'localhost';
+process.env.DB_NAME = 'testdb';
+process.env.DB_PORT = '5432';
+process.env.CORS_ORIGINS = '*';
+// Disable swagger file scanning during tests (avoids filesystem glob)
+process.env.ENABLE_API_DOCS = 'false';
+// Disable Sentry in tests
+delete process.env.ENVIRONMENT;

--- a/web-api/__tests__/utils/dbFilter.test.js
+++ b/web-api/__tests__/utils/dbFilter.test.js
@@ -1,0 +1,106 @@
+/**
+ * Unit tests for utils/dbFilter.js — createDBFilter
+ *
+ * createDBFilter(query) translates req.query parameters into a Knex Raw object
+ * containing a SQL WHERE clause fragment and bindings.
+ *
+ * We mock db so that db.raw(sql, params) is captured and we can assert on the
+ * generated SQL template and parameter object without hitting PostgreSQL.
+ */
+
+jest.mock('../../db');
+
+const db = require('../../db');
+const { setupDbMock } = require('../helpers/mockDb');
+const createDBFilter = require('../../utils/dbFilter');
+
+// Capture what db.raw is called with
+let lastSql = '';
+let lastParams = {};
+
+beforeEach(() => {
+  db.mockImplementation(() => ({}));
+  db.raw = jest.fn((sql, params) => {
+    lastSql = sql || '';
+    lastParams = params || {};
+    return { sql: sql || '', toSQL: () => ({ sql: sql || '', bindings: [] }) };
+  });
+});
+
+afterEach(() => jest.clearAllMocks());
+
+describe('createDBFilter', () => {
+  it('returns an object with a sql property', () => {
+    const result = createDBFilter({});
+    expect(result).toHaveProperty('sql');
+  });
+
+  it('produces empty SQL for an empty query', () => {
+    createDBFilter({});
+    expect(lastSql).toBe('');
+  });
+
+  it('adds eovs filter with && operator', () => {
+    createDBFilter({ eovs: 'seaSurfaceTemperature,salinity' });
+    expect(lastSql).toContain('eovs &&');
+    expect(lastParams.eovsCommaSeparatedString).toEqual(['seaSurfaceTemperature', 'salinity']);
+  });
+
+  it('deduplicates eov values', () => {
+    createDBFilter({ eovs: 'salinity,salinity' });
+    expect(lastParams.eovsCommaSeparatedString).toEqual(['salinity']);
+  });
+
+  it('adds timeMin filter with timestamptz cast', () => {
+    createDBFilter({ timeMin: '2020-01-01T00:00:00Z' });
+    expect(lastSql).toContain('time_max >= :timeMin::timestamptz');
+    expect(lastParams.timeMin).toBe('2020-01-01T00:00:00Z');
+  });
+
+  it('adds timeMax filter with timestamptz cast', () => {
+    createDBFilter({ timeMax: '2023-12-31T00:00:00Z' });
+    expect(lastSql).toContain('time_min <= :timeMax::timestamptz');
+    expect(lastParams.timeMax).toBe('2023-12-31T00:00:00Z');
+  });
+
+  it('adds latMin / latMax filters', () => {
+    createDBFilter({ latMin: '45', latMax: '55' });
+    expect(lastSql).toContain('latitude >= (:latMin)::double precision');
+    expect(lastSql).toContain('latitude <= (:latMax)::double precision');
+  });
+
+  it('adds lonMin / lonMax filters', () => {
+    createDBFilter({ lonMin: '-130', lonMax: '-120' });
+    expect(lastSql).toContain('longitude >= (:lonMin)::double precision');
+    expect(lastSql).toContain('longitude <= (:lonMax)::double precision');
+  });
+
+  it('adds depthMin / depthMax filters', () => {
+    createDBFilter({ depthMin: '0', depthMax: '200' });
+    expect(lastSql).toContain('depth_max >= (:depthMin)::integer');
+    expect(lastSql).toContain('depth_min <= (:depthMax)::integer');
+  });
+
+  it('adds datasetPKs filter with ANY', () => {
+    createDBFilter({ datasetPKs: '1,2,3' });
+    expect(lastSql).toContain('d.pk_url = ANY (:datasetPKs)');
+    expect(lastParams.datasetPKs).toEqual(['1', '2', '3']);
+  });
+
+  it('adds organizations filter with && operator', () => {
+    createDBFilter({ organizations: '10,20' });
+    expect(lastSql).toContain('organization_pks && :organizationsString');
+  });
+
+  it('adds polygon filter with ST_Contains', () => {
+    const polygon = JSON.stringify([[-130, 45], [-120, 45], [-120, 55], [-130, 55], [-130, 45]]);
+    createDBFilter({ polygon });
+    expect(lastSql).toContain('ST_Contains');
+    expect(lastParams.wktPolygon).toMatch(/^POLYGON\(/);
+  });
+
+  it('joins multiple filters with AND', () => {
+    createDBFilter({ timeMin: '2020-01-01T00:00:00Z', timeMax: '2023-12-31T00:00:00Z' });
+    expect(lastSql).toContain('AND');
+  });
+});

--- a/web-api/__tests__/utils/polygon.test.js
+++ b/web-api/__tests__/utils/polygon.test.js
@@ -1,0 +1,59 @@
+/**
+ * Unit tests for utils/polygon.js — polygonJSONToWKT
+ *
+ * Pure function: no database or HTTP calls required.
+ * Input: JSON string representing [[lat, lon], ...] coordinate array.
+ * Output: WKT POLYGON string, or false if input is invalid.
+ */
+
+const { polygonJSONToWKT } = require('../../utils/polygon');
+
+// Minimal valid closed polygon (5 points, first = last)
+const VALID_POLYGON = JSON.stringify([
+  [-130, 45], [-120, 45], [-120, 55], [-130, 55], [-130, 45],
+]);
+
+// Triangle — only 3 unique points (4 with closing = 4 total, which is the minimum)
+const TRIANGLE_POLYGON = JSON.stringify([
+  [-130, 45], [-120, 45], [-125, 55], [-130, 45],
+]);
+
+describe('polygonJSONToWKT', () => {
+  it('converts a valid closed polygon to a WKT POLYGON string', () => {
+    const result = polygonJSONToWKT(VALID_POLYGON);
+    expect(result).toMatch(/^POLYGON\(/);
+  });
+
+  it('WKT contains the original coordinates', () => {
+    const result = polygonJSONToWKT(VALID_POLYGON);
+    // First coordinate pair is [-130, 45] → "−130 45" in WKT
+    expect(result).toContain('-130 45');
+  });
+
+  it('accepts the minimum 4-point polygon (triangle + closing point)', () => {
+    const result = polygonJSONToWKT(TRIANGLE_POLYGON);
+    expect(result).not.toBe(false);
+    expect(result).toMatch(/^POLYGON\(/);
+  });
+
+  it('returns false for a polygon with fewer than 4 points', () => {
+    const twoPoints = JSON.stringify([[-130, 45], [-120, 45]]);
+    expect(polygonJSONToWKT(twoPoints)).toBe(false);
+  });
+
+  it('returns false for invalid JSON', () => {
+    expect(polygonJSONToWKT('not-json')).toBe(false);
+  });
+
+  it('returns false for an empty string', () => {
+    expect(polygonJSONToWKT('')).toBe(false);
+  });
+
+  it('returns false for undefined input', () => {
+    expect(polygonJSONToWKT(undefined)).toBe(false);
+  });
+
+  it('returns false for an empty array', () => {
+    expect(polygonJSONToWKT('[]')).toBe(false);
+  });
+});

--- a/web-api/package-lock.json
+++ b/web-api/package-lock.json
@@ -40,7 +40,9 @@
       "devDependencies": {
         "eslint": "^8.24.0",
         "eslint-config-airbnb-base": "^15.0.0",
-        "eslint-plugin-import": "^2.26.0"
+        "eslint-plugin-import": "^2.26.0",
+        "jest": "^30.4.2",
+        "supertest": "^7.2.2"
       }
     },
     "node_modules/@apidevtools/json-schema-ref-parser": {
@@ -87,11 +89,597 @@
         "openapi-types": ">=7"
       }
     },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/core/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@babel/core/node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@babel/core/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "dev": true,
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "dev": true,
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-async-generators": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
+      "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-bigint": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
+      "integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-class-properties": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
+      "integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-class-static-block": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz",
+      "integrity": "sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-import-attributes": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.29.7.tgz",
+      "integrity": "sha512-zGYcYfq/WmZ4V+kBIXQon9dSSc8ircGZqw9ZaNhhGj9nZkeBu1jHLBDQqYYi5WA9uawvA2sIMbry2nCFhf5Djg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-import-meta": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
+      "integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-json-strings": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
+      "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-jsx": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.29.7.tgz",
+      "integrity": "sha512-TSu8+mHCoEaaCDEZ0I3+6mvTBYR4PCxQwf2z9/r5Tbztv6NaLR3B9thGTTxX2WGuGHJqRiAbKPeGTJ5XWXVg6A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-logical-assignment-operators": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
+      "integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-nullish-coalescing-operator": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
+      "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-numeric-separator": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
+      "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-object-rest-spread": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
+      "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-optional-catch-binding": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
+      "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-optional-chaining": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
+      "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-private-property-in-object": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
+      "integrity": "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-top-level-await": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
+      "integrity": "sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-typescript": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.29.7.tgz",
+      "integrity": "sha512-ngr+82Sh0xMz25TPCZi+nC2iTzjfCdWS2ONXTp/PtSCHCgaCNBpdMqgvJ2ccdLlClVZ7sisIgB914j/JFe+RZA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@babel/traverse/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true
+    },
     "node_modules/@cacheable/utils": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@cacheable/utils/-/utils-2.0.2.tgz",
       "integrity": "sha512-JTFM3raFhVv8LH95T7YnZbf2YoE9wEtkPPStuRF9a6ExZ103hFvs+QyCuYJ6r0hA9wRtbzgZtwUCoDWxssZd4Q==",
       "license": "MIT"
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/core/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "optional": true
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.0",
@@ -239,6 +827,623 @@
       "integrity": "sha512-aFT2yemJJo+TZCmieA7qnYGQooOS7QfNmYrzGtsYd3g9j5iDP8AimYYAesf79ohjbLG12XxC4nG5DyEnC88AsQ==",
       "license": "MIT"
     },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true
+    },
+    "node_modules/@isaacs/cliui/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
+      "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
+      "dev": true,
+      "dependencies": {
+        "camelcase": "^5.3.1",
+        "find-up": "^4.1.0",
+        "get-package-type": "^0.1.0",
+        "js-yaml": "^3.13.1",
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/console": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-30.4.1.tgz",
+      "integrity": "sha512-v3bhyxUh9Hgmo5p6hAOXe14/R3ZxZDOsvHleh4B07z3m/x4/ngPUXEm9XwK4sF4u+f+P2ORb0Ge+MgpaqRMVDA==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "jest-message-util": "30.4.1",
+        "jest-util": "30.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/core": {
+      "version": "30.4.2",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-30.4.2.tgz",
+      "integrity": "sha512-TZJA6cPJUFxoWhxaLo8t0VX/MZX2wPWr0uIDvLSHIvN4gu9h02vSzqI2kBADG1ExqQlC+cY09xKMSreivvrChQ==",
+      "dev": true,
+      "dependencies": {
+        "@jest/console": "30.4.1",
+        "@jest/pattern": "30.4.0",
+        "@jest/reporters": "30.4.1",
+        "@jest/test-result": "30.4.1",
+        "@jest/transform": "30.4.1",
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "ansi-escapes": "^4.3.2",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "exit-x": "^0.2.2",
+        "fast-json-stable-stringify": "^2.1.0",
+        "graceful-fs": "^4.2.11",
+        "jest-changed-files": "30.4.1",
+        "jest-config": "30.4.2",
+        "jest-haste-map": "30.4.1",
+        "jest-message-util": "30.4.1",
+        "jest-regex-util": "30.4.0",
+        "jest-resolve": "30.4.1",
+        "jest-resolve-dependencies": "30.4.2",
+        "jest-runner": "30.4.2",
+        "jest-runtime": "30.4.2",
+        "jest-snapshot": "30.4.1",
+        "jest-util": "30.4.1",
+        "jest-validate": "30.4.1",
+        "jest-watcher": "30.4.1",
+        "pretty-format": "30.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/diff-sequences": {
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.4.0.tgz",
+      "integrity": "sha512-zOpzlfUs45l6u7jm39qr87JCHUDsaeCtvL+kQe/Vn9jSnRB4/5IPXISm0h9I1vZW/o00Kn4UTJ2MOlhnUGwv3g==",
+      "dev": true,
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/environment": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.4.1.tgz",
+      "integrity": "sha512-AK9yNRqgKxiabqMoe4oW+3/TSSeV8vkdC7BGaxZdU0AFXfOpofTLqdru2GXKZghP3sdgwE9XXpnVwfZ8JnFV4w==",
+      "dev": true,
+      "dependencies": {
+        "@jest/fake-timers": "30.4.1",
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "jest-mock": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/expect": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-30.4.1.tgz",
+      "integrity": "sha512-ginrj6TMgh2GshLUGCjO94Ptx9HhdZA/I6A9iUfyeLKFtdAjnKzHDgzgP9HYQgbxM1lbXScQ2eUBz2lGeVDPWA==",
+      "dev": true,
+      "dependencies": {
+        "expect": "30.4.1",
+        "jest-snapshot": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/expect-utils": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.4.1.tgz",
+      "integrity": "sha512-ZBn5CglH8fBsQsvs4VWNzD4aWfUYks+IdOOQU3MEK71ol/BcVm+P+rtb1KpiFBpSWSCE27uOahyyf1vfqOVbcQ==",
+      "dev": true,
+      "dependencies": {
+        "@jest/get-type": "30.1.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/fake-timers": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.4.1.tgz",
+      "integrity": "sha512-iW5umdmfPeWzehrVhugFQZqCchSCud5S1l2YT0O9ZhjRR0ExclANDZkiSBwzqtnlOn0J1JXvO+HZ6rkuyOVOgQ==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "30.4.1",
+        "@sinonjs/fake-timers": "^15.4.0",
+        "@types/node": "*",
+        "jest-message-util": "30.4.1",
+        "jest-mock": "30.4.1",
+        "jest-util": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/get-type": {
+      "version": "30.1.0",
+      "resolved": "https://registry.npmjs.org/@jest/get-type/-/get-type-30.1.0.tgz",
+      "integrity": "sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==",
+      "dev": true,
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/globals": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-30.4.1.tgz",
+      "integrity": "sha512-ZbuY4cmXC8DkxYjfvT2DbcHWL2T6vmsMhXCDcmTB2T0y0gaezBI77ufq5ZAIdcRkYZ7NEQEDg1xFeKbxUJ5v5Q==",
+      "dev": true,
+      "dependencies": {
+        "@jest/environment": "30.4.1",
+        "@jest/expect": "30.4.1",
+        "@jest/types": "30.4.1",
+        "jest-mock": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/pattern": {
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.4.0.tgz",
+      "integrity": "sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "jest-regex-util": "30.4.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/reporters": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-30.4.1.tgz",
+      "integrity": "sha512-/SnkPCzEQpUaBH81kjdEdDdo2WZl5hxw+BmLDGWjRkm8o7XlhjwsU36cqwe5PGBE5WYpBvDzRSdXx9rbGuJtNA==",
+      "dev": true,
+      "dependencies": {
+        "@bcoe/v8-coverage": "^0.2.3",
+        "@jest/console": "30.4.1",
+        "@jest/test-result": "30.4.1",
+        "@jest/transform": "30.4.1",
+        "@jest/types": "30.4.1",
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "collect-v8-coverage": "^1.0.2",
+        "exit-x": "^0.2.2",
+        "glob": "^10.5.0",
+        "graceful-fs": "^4.2.11",
+        "istanbul-lib-coverage": "^3.0.0",
+        "istanbul-lib-instrument": "^6.0.0",
+        "istanbul-lib-report": "^3.0.0",
+        "istanbul-lib-source-maps": "^5.0.0",
+        "istanbul-reports": "^3.1.3",
+        "jest-message-util": "30.4.1",
+        "jest-util": "30.4.1",
+        "jest-worker": "30.4.1",
+        "slash": "^3.0.0",
+        "string-length": "^4.0.2",
+        "v8-to-istanbul": "^9.0.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/brace-expansion": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@jest/schemas": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
+      "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
+      "dev": true,
+      "dependencies": {
+        "@sinclair/typebox": "^0.34.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/snapshot-utils": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/snapshot-utils/-/snapshot-utils-30.4.1.tgz",
+      "integrity": "sha512-ObY4ljvQ95mt6iwKtVLetR/4yXiAgl3H4nJxhztr0MTjrN97TwDYrnCp/kF60Ec9HdhkWTHSu+Hg05aXfngpOA==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "30.4.1",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "natural-compare": "^1.4.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/source-map": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-30.0.1.tgz",
+      "integrity": "sha512-MIRWMUUR3sdbP36oyNyhbThLHyJ2eEDClPCiHVbrYAe5g3CHRArIVpBw7cdSB5fr+ofSfIb2Tnsw8iEHL0PYQg==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "callsites": "^3.1.0",
+        "graceful-fs": "^4.2.11"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/test-result": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-30.4.1.tgz",
+      "integrity": "sha512-/ZG7pgEiOmmWkN9TplKbOu4id2N5lh7FHwRwlkgBVAzGdRH+OkkQ8wX/kIxg4zmd3ZQvAL1RwL2yWsvNYYECTw==",
+      "dev": true,
+      "dependencies": {
+        "@jest/console": "30.4.1",
+        "@jest/types": "30.4.1",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "collect-v8-coverage": "^1.0.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/test-sequencer": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-30.4.1.tgz",
+      "integrity": "sha512-PeYE+4td5rKjoRPxztObrXU+H8hsjZfxKMXOcmrr34JerSyB/ROOxbbicz8B7A5j9R9VayDnVPvBmedqCsFCdw==",
+      "dev": true,
+      "dependencies": {
+        "@jest/test-result": "30.4.1",
+        "graceful-fs": "^4.2.11",
+        "jest-haste-map": "30.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/transform": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-30.4.1.tgz",
+      "integrity": "sha512-Wz0LyktlTvRefoymh+n64hQ84KNXsRGcwdoZ8CSa0Ea+fgYcHZlnk+hDP7v2MS7il2bQ5uTEIxf4/NNfhMN4KQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.27.4",
+        "@jest/types": "30.4.1",
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "babel-plugin-istanbul": "^7.0.1",
+        "chalk": "^4.1.2",
+        "convert-source-map": "^2.0.0",
+        "fast-json-stable-stringify": "^2.1.0",
+        "graceful-fs": "^4.2.11",
+        "jest-haste-map": "30.4.1",
+        "jest-regex-util": "30.4.0",
+        "jest-util": "30.4.1",
+        "pirates": "^4.0.7",
+        "slash": "^3.0.0",
+        "write-file-atomic": "^5.0.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/types": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.4.1.tgz",
+      "integrity": "sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==",
+      "dev": true,
+      "dependencies": {
+        "@jest/pattern": "30.4.0",
+        "@jest/schemas": "30.4.1",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "@types/istanbul-reports": "^3.0.4",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.33",
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
     "node_modules/@jsdevtools/ono": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
@@ -260,6 +1465,36 @@
         "to4326": "bin/to4326.js",
         "to900913": "bin/to900913.js",
         "xyz": "bin/xyz.js"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -295,6 +1530,37 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
+      "integrity": "sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==",
+      "dev": true,
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@pkgr/core": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.3.6.tgz",
+      "integrity": "sha512-SEeaJLb3qBNF/OaXnaR1NmmBbFYk1zC0ZH/52fATcRPLFg/p791YrcyFFy44Bo9sLaGuSuLp5Q6axbb/O+v/RA==",
+      "dev": true,
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pkgr"
       }
     },
     "node_modules/@redis/bloom": {
@@ -472,6 +1738,112 @@
         "node": ">=6"
       }
     },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.34.49",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
+      "integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==",
+      "dev": true
+    },
+    "node_modules/@sinonjs/commons": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+      "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/fake-timers": {
+      "version": "15.4.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.4.0.tgz",
+      "integrity": "sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1"
+      }
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tybys/wasm-util/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/istanbul-lib-coverage": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+      "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
+      "dev": true
+    },
+    "node_modules/@types/istanbul-lib-report": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
+      "integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
+      "dev": true,
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "*"
+      }
+    },
+    "node_modules/@types/istanbul-reports": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
+      "integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/istanbul-lib-report": "*"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -485,11 +1857,332 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "25.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
+      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
+    "node_modules/@types/stack-utils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
+      "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
+      "dev": true
+    },
+    "node_modules/@types/yargs": {
+      "version": "17.0.35",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
+      "integrity": "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==",
+      "dev": true,
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/@types/yargs-parser": {
+      "version": "21.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
+      "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
+      "dev": true
+    },
     "node_modules/@ungap/structured-clone": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "license": "ISC"
+    },
+    "node_modules/@unrs/resolver-binding-android-arm-eabi": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.12.2.tgz",
+      "integrity": "sha512-g5T90pqg1bo/7mytQx6F4iBNC0Wsh9cu+z9veDbFjc7HjpesJFWD7QMS0NGStXM075+7dJPPVvBbpZlnrdpi/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-android-arm64": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.12.2.tgz",
+      "integrity": "sha512-YGCRZv/9GLhwmz6mYDeTsm/92BAyR28l6c2ReweVW5pWgfsitWLY8upvfRlGdoyD8HjeTHSYJWyZGD4KJA/nFQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-darwin-arm64": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.12.2.tgz",
+      "integrity": "sha512-u9DiNT1auQMO20A9SyTuG3wUgQWB9Z7KjAg0uFuCDR1FsAY8A0CG2S6JpHS1xwm/w1G08bjXZDcyOCjv1WAm2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-darwin-x64": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.12.2.tgz",
+      "integrity": "sha512-f7rPLi/T1HVKZu/u6t87lroib16n8vrSzcyxI7lg4BGO9UF26KhQL44sd9eOUgrTYhvRXtWOIZT5PejdPyJfUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-freebsd-x64": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.12.2.tgz",
+      "integrity": "sha512-BpcOjWCJub6nRZUS2zA20pmLvjtqAtGejETaIyRLiZiQf++cbrjltLA5NN/xaXfqeOBOSlMFbemIl5/S5tljmg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.12.2.tgz",
+      "integrity": "sha512-vZTDvdSISZjJx66OzJqtsOhzifbqRjbmI1Mnu49fQDwog5GtDI4QidRiEAYbZCRj9C8YZEW+3ZjqsyS9GR4k2A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.12.2.tgz",
+      "integrity": "sha512-BiPI+IrIlwcW4nLLMM21+B1dFPzd55yAVgVGrdgDjNef+ch03GdxrcyaIz8X9SsQirh/kCQ7mviyWlMxdh2D7g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.12.2.tgz",
+      "integrity": "sha512-zJc0H99FEPoFfSrNpa91HYfxzfAJCr502oxNK1cfdC9hlaFI43RT+JFCann9JUgZmLzzntChHyn13Sgn9ljHNg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm64-musl": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.12.2.tgz",
+      "integrity": "sha512-KQ3Lki6l+Pz1k/eBipN41ES+YUK30beLGb9YqcB1O542cyLCNE6GaxrfcY3T6EezmGGk84wb5XyO9loTM9tkcA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-loong64-gnu": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-loong64-gnu/-/resolver-binding-linux-loong64-gnu-1.12.2.tgz",
+      "integrity": "sha512-3SJGEh1DborhG6pyxvhPzCT4bbSIVihsvgJc13P1bHG7KLdNDaF9T3gsTwFc7Jw/5Y5/iWOjkEx7Zy0NvCGX3Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-loong64-musl": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-loong64-musl/-/resolver-binding-linux-loong64-musl-1.12.2.tgz",
+      "integrity": "sha512-jiuG/Obbel7uw1PwHNFfrkiKhLAF6mnyZ6aWlOAVN9WqKm8v0OFGnciJIHu8+CMvXLQ8AD51LPzAoUfT21D5Ew==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.12.2.tgz",
+      "integrity": "sha512-q7xRvVpmcfeL+LlZg8Pbbo6QaTZwDU5BaGZbwfhkEsXJn3Was8xYfE0RBH266xZt0rM6B7i8xAYIvjthuUIWHg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.12.2.tgz",
+      "integrity": "sha512-0CVdx6lcnT3Q9inOH8tsMIOJ6ImndllMjqJHg8RLVdB7Vq4SfkEXl9mCSsVNuNA4MCYycRicCUxPCabVHJRr6A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.12.2.tgz",
+      "integrity": "sha512-iOwlRo9vnp6R6ohHQS11n0NnfdXx/omhkocmIfaPRpQhKZ+3BDMkkdRVh53qjkFkpPddf+FETA28NwGN7l5l+w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.12.2.tgz",
+      "integrity": "sha512-HYJtLfXq94q8iZNFT1lknx258wlkkWhZeUXJRqzKBBUJ00CvZ+N33zgbCqimLjsyw5Va6uUxhVa12mI+kaveEw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.12.2.tgz",
+      "integrity": "sha512-mPsUhunKKDih5O96Y6enDQyHc1SqBPlY1E/SfMWDM3EdJ95Z9CArPeCVwCCqbP45ljvivdEk8Fxn+SIb1rDAJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-x64-musl": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.12.2.tgz",
+      "integrity": "sha512-azrt6+5ydLd8Vt210AAFis/lZevSfPw93EJRIJG+xPu4WCJ8K0kppCTpMyLPcKT7H15M4Jnt2tMp5bOvCkRC6A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-openharmony-arm64": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-openharmony-arm64/-/resolver-binding-openharmony-arm64-1.12.2.tgz",
+      "integrity": "sha512-YZ9hP4O0X9PQb8eO980qmLNGH4zT3I9+SZTdt0Pr0YyuGQhYKoOZkV02VzrzyOZJ5xIJ3UFIenKkUkGg8GjgWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-wasm32-wasi": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.12.2.tgz",
+      "integrity": "sha512-tYFDIkMxSflfEc/h92ZWNsZlHSwgimbNHSO3PL2JWQHfCuC2q316jMyYU9TIWZsFK2bQwyK5VAdYgn8ygPj69A==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.12.2.tgz",
+      "integrity": "sha512-qzNyg3xL0VPQmCaUh+N5jSitce6k+uCBfMDesWRnlULOZaqUkaJ0ybdT+UqlAWJoQjuqfIU/0Ptx9bteN4D82g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.12.2.tgz",
+      "integrity": "sha512-WD9sY00OfpHVGfsnHZoA8jVT+esS/Bg8z8jzxp5BnDCjjwsuKsPQrzswwpFy4J1AUJbXPRfkpcX0mXrzeXW79g==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-win32-x64-msvc": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.12.2.tgz",
+      "integrity": "sha512-nAB74NfSNKknqQ1RrYj6uz8FcXEomu/MATJZxh/x+BArzN2U3JbOYC0APYzUIGhVY3m5hRxA8VPNdPBoG8txlA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/accepts": {
       "version": "1.3.8",
@@ -576,6 +2269,33 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "dev": true,
+      "dependencies": {
+        "type-fest": "^0.21.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-escapes/node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -598,6 +2318,31 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/anymatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/apicache": {
@@ -743,6 +2488,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true
+    },
     "node_modules/async-function": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
@@ -786,11 +2537,114 @@
         "proxy-from-env": "^1.1.0"
       }
     },
+    "node_modules/babel-jest": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.4.1.tgz",
+      "integrity": "sha512-fATAbM8piYxkiXQp3RBXmZHxZVNJZAVXXfyeyCN2Tida3+qJ8ea9UxhiJ2y4fLO90ZImKt6k9FlcH2+rLkJGhw==",
+      "dev": true,
+      "dependencies": {
+        "@jest/transform": "30.4.1",
+        "@types/babel__core": "^7.20.5",
+        "babel-plugin-istanbul": "^7.0.1",
+        "babel-preset-jest": "30.4.0",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.11.0 || ^8.0.0-0"
+      }
+    },
+    "node_modules/babel-plugin-istanbul": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-7.0.1.tgz",
+      "integrity": "sha512-D8Z6Qm8jCvVXtIRkBnqNHX0zJ37rQcFJ9u8WOS6tkYOsRdHBzypCstaxWiu5ZIlqQtviRYbgnRLSoCEvjqcqbA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@istanbuljs/load-nyc-config": "^1.0.0",
+        "@istanbuljs/schema": "^0.1.3",
+        "istanbul-lib-instrument": "^6.0.2",
+        "test-exclude": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/babel-plugin-jest-hoist": {
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-30.4.0.tgz",
+      "integrity": "sha512-9EdtWM/sSfXLOGLwSn+GS6pIXyBnL07/8gyJlwFXjWy4DxMOyItqyUT29d4lQiS380EZwYlX7/At4PgBS+m2aA==",
+      "dev": true,
+      "dependencies": {
+        "@types/babel__core": "^7.20.5"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/babel-preset-current-node-syntax": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.2.0.tgz",
+      "integrity": "sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/plugin-syntax-async-generators": "^7.8.4",
+        "@babel/plugin-syntax-bigint": "^7.8.3",
+        "@babel/plugin-syntax-class-properties": "^7.12.13",
+        "@babel/plugin-syntax-class-static-block": "^7.14.5",
+        "@babel/plugin-syntax-import-attributes": "^7.24.7",
+        "@babel/plugin-syntax-import-meta": "^7.10.4",
+        "@babel/plugin-syntax-json-strings": "^7.8.3",
+        "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+        "@babel/plugin-syntax-numeric-separator": "^7.10.4",
+        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+        "@babel/plugin-syntax-optional-chaining": "^7.8.3",
+        "@babel/plugin-syntax-private-property-in-object": "^7.14.5",
+        "@babel/plugin-syntax-top-level-await": "^7.14.5"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0 || ^8.0.0-0"
+      }
+    },
+    "node_modules/babel-preset-jest": {
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-30.4.0.tgz",
+      "integrity": "sha512-lBY4jxsNmCnSiu7kquw8ZC9F4+XLMOKypT3RnNHPvU2Kpd4W0xaPuLr5ZkRyOsvLYAY4yaW1ZwTW4xB7NIiZzg==",
+      "dev": true,
+      "dependencies": {
+        "babel-plugin-jest-hoist": "30.4.0",
+        "babel-preset-current-node-syntax": "^1.2.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.11.0 || ^8.0.0-beta.1"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.33",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.33.tgz",
+      "integrity": "sha512-bA6+tcSLpz2tIEdDXZPpPTIuxBcC4+w6SieaYyfigIa4h8GlFxbA17v22Vx3JUtuZQj9SgOsnbK+aTBzyDyEuw==",
+      "dev": true,
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/basic-auth": {
       "version": "2.0.1",
@@ -865,6 +2719,54 @@
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/bser": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
+      "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
+      "dev": true,
+      "dependencies": {
+        "node-int64": "^0.4.0"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -948,6 +2850,35 @@
         "node": ">=6"
       }
     },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001793",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
+      "integrity": "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ]
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -964,6 +2895,50 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/char-regex": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
+      "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ci-info": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+      "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
+      "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
+      "dev": true
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/cluster-key-slot": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
@@ -972,6 +2947,22 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
+      "dev": true,
+      "engines": {
+        "iojs": ">= 1.0.0",
+        "node": ">= 0.12.0"
+      }
+    },
+    "node_modules/collect-v8-coverage": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.3.tgz",
+      "integrity": "sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw==",
+      "dev": true
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
@@ -1018,6 +3009,15 @@
         "node": ">=14"
       }
     },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -1052,6 +3052,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true
+    },
     "node_modules/cookie": {
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
@@ -1079,6 +3085,12 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
       "license": "MIT"
+    },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true
     },
     "node_modules/cors": {
       "version": "2.8.5",
@@ -1170,11 +3182,34 @@
         "ms": "2.0.0"
       }
     },
+    "node_modules/dedent": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
+      "integrity": "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==",
+      "dev": true,
+      "peerDependencies": {
+        "babel-plugin-macros": "^3.1.0"
+      },
+      "peerDependenciesMeta": {
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "license": "MIT"
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/define-data-property": {
       "version": "1.1.4",
@@ -1249,6 +3284,25 @@
         "npm": "1.2.8000 || >= 1.4.16"
       }
     },
+    "node_modules/detect-newline": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
+      "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
+      }
+    },
     "node_modules/doctrine": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -1284,11 +3338,41 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "license": "MIT"
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.366",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.366.tgz",
+      "integrity": "sha512-OlRuhb688YTCzzU3gXPLn6nGyd+F+53INE1qaKKlu6kETErE8FYsyDh0XqXEU+uBRn0MpCzz2vfNwORhkap8qg==",
+      "dev": true
+    },
+    "node_modules/emittery": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.13.1.tgz",
+      "integrity": "sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/emittery?sponsor=1"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
@@ -1297,6 +3381,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+      "dev": true,
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
       }
     },
     "node_modules/es-abstract": {
@@ -1764,6 +3857,19 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/esquery": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
@@ -1813,6 +3919,55 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/exit-x": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/exit-x/-/exit-x-0.2.2.tgz",
+      "integrity": "sha512-+I6B/IkJc1o/2tiURyz/ivu/O0nKNEArIUB5O7zBrlDVJr22SCLH3xTeEry428LvFhRzIA1g8izguxJ/gbNcVQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/expect": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-30.4.1.tgz",
+      "integrity": "sha512-PMARsyh/JtqC20HoGqlFcIlQAyqUtW4PlI1rup1uhYJtKuwAjbvWi3GQMAn+STdHum/dk8xrKfUM1+5SAwpolA==",
+      "dev": true,
+      "dependencies": {
+        "@jest/expect-utils": "30.4.1",
+        "@jest/get-type": "30.1.0",
+        "jest-matcher-utils": "30.4.1",
+        "jest-message-util": "30.4.1",
+        "jest-mock": "30.4.1",
+        "jest-util": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/express": {
@@ -1923,6 +4078,12 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "license": "MIT"
     },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true
+    },
     "node_modules/fastq": {
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
@@ -1930,6 +4091,15 @@
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fb-watchman": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
+      "integrity": "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==",
+      "dev": true,
+      "dependencies": {
+        "bser": "2.1.1"
       }
     },
     "node_modules/file-entry-cache": {
@@ -2043,11 +4213,38 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/foreground-child/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/form-data": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
-      "license": "MIT",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -2057,6 +4254,23 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
+      "dev": true,
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
     "node_modules/forwarded": {
@@ -2082,6 +4296,20 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
@@ -2121,6 +4349,24 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/get-intrinsic": {
@@ -2167,6 +4413,18 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-symbol-description": {
@@ -2270,6 +4528,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true
+    },
     "node_modules/graphemer": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
@@ -2366,6 +4630,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true
+    },
     "node_modules/http-errors": {
       "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
@@ -2441,6 +4711,15 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -2473,6 +4752,25 @@
       },
       "engines": {
         "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/import-local": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
+      "integrity": "sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==",
+      "dev": true,
+      "dependencies": {
+        "pkg-dir": "^4.2.0",
+        "resolve-cwd": "^3.0.0"
+      },
+      "bin": {
+        "import-local-fixture": "fixtures/cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -2601,6 +4899,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true
     },
     "node_modules/is-async-function": {
       "version": "2.1.1",
@@ -2743,6 +5047,24 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-generator-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
+      "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/is-generator-function": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.0.tgz",
@@ -2874,6 +5196,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-string": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
@@ -2984,6 +5318,792 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-instrument": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
+      "integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.23.9",
+        "@babel/parser": "^7.23.9",
+        "@istanbuljs/schema": "^0.1.3",
+        "istanbul-lib-coverage": "^3.2.0",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-instrument/node_modules/semver": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/istanbul-lib-source-maps/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/jest": {
+      "version": "30.4.2",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-30.4.2.tgz",
+      "integrity": "sha512-Yi1jqNC/Oq0N4hBgNH/YvBpP1P57QqundgytzYqy3yqAa7NZPNjSoi4SGbRAXDMdBzNE6xBCi5U7RgfrvMEUVQ==",
+      "dev": true,
+      "dependencies": {
+        "@jest/core": "30.4.2",
+        "@jest/types": "30.4.1",
+        "import-local": "^3.2.0",
+        "jest-cli": "30.4.2"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-changed-files": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-30.4.1.tgz",
+      "integrity": "sha512-IuctmYrxi21iOSOaIXpJWalHyPAsVv0GeBHKDn8C1CA4W5htHn7INL+wdnL4Bo0+olEndvAFkmb++tIQJG+vvg==",
+      "dev": true,
+      "dependencies": {
+        "execa": "^5.1.1",
+        "jest-util": "30.4.1",
+        "p-limit": "^3.1.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-circus": {
+      "version": "30.4.2",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-30.4.2.tgz",
+      "integrity": "sha512-rvHH7VlY6LgbJXJTQ87GW62g1FntOtbhh0zT+v04kC+pgL6aBKyYINXxWukCpj3dcIBMw5/XUbtDS9dU9JTXeQ==",
+      "dev": true,
+      "dependencies": {
+        "@jest/environment": "30.4.1",
+        "@jest/expect": "30.4.1",
+        "@jest/test-result": "30.4.1",
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "co": "^4.6.0",
+        "dedent": "^1.6.0",
+        "is-generator-fn": "^2.1.0",
+        "jest-each": "30.4.1",
+        "jest-matcher-utils": "30.4.1",
+        "jest-message-util": "30.4.1",
+        "jest-runtime": "30.4.2",
+        "jest-snapshot": "30.4.1",
+        "jest-util": "30.4.1",
+        "p-limit": "^3.1.0",
+        "pretty-format": "30.4.1",
+        "pure-rand": "^7.0.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.6"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-cli": {
+      "version": "30.4.2",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-30.4.2.tgz",
+      "integrity": "sha512-jfA2ocvVHMXS2QijrJ0d31ektP+d/W0T5RpcTX2Pq+3sVqHlsXVCM2+FmwpL+bdY8OfHpIg9xMxLF17Zg0U49Q==",
+      "dev": true,
+      "dependencies": {
+        "@jest/core": "30.4.2",
+        "@jest/test-result": "30.4.1",
+        "@jest/types": "30.4.1",
+        "chalk": "^4.1.2",
+        "exit-x": "^0.2.2",
+        "import-local": "^3.2.0",
+        "jest-config": "30.4.2",
+        "jest-util": "30.4.1",
+        "jest-validate": "30.4.1",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-config": {
+      "version": "30.4.2",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-30.4.2.tgz",
+      "integrity": "sha512-rNHAShJQqQwFNoL0hbf3BphSBOWnpOUAKvidLS/AjNVLPfoj5mSf4jQMfW3cYOs6hXeZC7nF7mDHaBnbxELOzg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.27.4",
+        "@jest/get-type": "30.1.0",
+        "@jest/pattern": "30.4.0",
+        "@jest/test-sequencer": "30.4.1",
+        "@jest/types": "30.4.1",
+        "babel-jest": "30.4.1",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "deepmerge": "^4.3.1",
+        "glob": "^10.5.0",
+        "graceful-fs": "^4.2.11",
+        "jest-circus": "30.4.2",
+        "jest-docblock": "30.4.0",
+        "jest-environment-node": "30.4.1",
+        "jest-regex-util": "30.4.0",
+        "jest-resolve": "30.4.1",
+        "jest-runner": "30.4.2",
+        "jest-util": "30.4.1",
+        "jest-validate": "30.4.1",
+        "parse-json": "^5.2.0",
+        "pretty-format": "30.4.1",
+        "slash": "^3.0.0",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@types/node": "*",
+        "esbuild-register": ">=3.4.0",
+        "ts-node": ">=9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "esbuild-register": {
+          "optional": true
+        },
+        "ts-node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-config/node_modules/brace-expansion": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/jest-config/node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/jest-config/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/jest-diff": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.4.1.tgz",
+      "integrity": "sha512-CRpFK0RtLriVDGcPPAnR6HMVI8bSR2jnUIgralhauzYQZIb4RH9AtEInTuQr65LmmGggGcRT6HIASxwqsVsmlA==",
+      "dev": true,
+      "dependencies": {
+        "@jest/diff-sequences": "30.4.0",
+        "@jest/get-type": "30.1.0",
+        "chalk": "^4.1.2",
+        "pretty-format": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-docblock": {
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-30.4.0.tgz",
+      "integrity": "sha512-ZPMabUZCx5MpbZ2eBYSvZ0J8fvo3dR9oM+eeUpb3aKNQFuS2tu3Duw1TNlMoP8k3WQgKGJuhcMFvwcVuq6T7oA==",
+      "dev": true,
+      "dependencies": {
+        "detect-newline": "^3.1.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-each": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-30.4.1.tgz",
+      "integrity": "sha512-/8MJbH6fuj48TstjrMf+u/pd06Qezz5xOXvZA6442heNOWr8bdeoGZX2d9fCn028CoMgYmroH9//zky5GfyYmA==",
+      "dev": true,
+      "dependencies": {
+        "@jest/get-type": "30.1.0",
+        "@jest/types": "30.4.1",
+        "chalk": "^4.1.2",
+        "jest-util": "30.4.1",
+        "pretty-format": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-environment-node": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-30.4.1.tgz",
+      "integrity": "sha512-4FZYVOk85hz2AyT6BbarKy9u37g6DbrDyCdFhsnDdXqyrueYQvB+0zO4f/kqLCRD0BsPRXPMNJeQwihKZV8naw==",
+      "dev": true,
+      "dependencies": {
+        "@jest/environment": "30.4.1",
+        "@jest/fake-timers": "30.4.1",
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "jest-mock": "30.4.1",
+        "jest-util": "30.4.1",
+        "jest-validate": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-haste-map": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-30.4.1.tgz",
+      "integrity": "sha512-rFrcONd8jeFsyw+Z9CrScJgglRf2+NFmNam8dKu7n+SoHqNYT47mn0DdEcVUZJpvh7Iz6/si7f7yUH7GJHVgnw==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "anymatch": "^3.1.3",
+        "fb-watchman": "^2.0.2",
+        "graceful-fs": "^4.2.11",
+        "jest-regex-util": "30.4.0",
+        "jest-util": "30.4.1",
+        "jest-worker": "30.4.1",
+        "picomatch": "^4.0.3",
+        "walker": "^1.0.8"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "^2.3.3"
+      }
+    },
+    "node_modules/jest-leak-detector": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-30.4.1.tgz",
+      "integrity": "sha512-IpmyiioeHxiWDhesHnUFmOxcTzwCwKpgACgWajtAP+nYQXiY7DakTxB6Bx9JFiRMljr0AX1PvnQdaU1KFoz6NQ==",
+      "dev": true,
+      "dependencies": {
+        "@jest/get-type": "30.1.0",
+        "pretty-format": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.4.1.tgz",
+      "integrity": "sha512-zvYfX5CaeEkFrrLS9suWe9rvJrm9J1Iv3ua8kIBv9GEPzcnsfBf0bob37la7s67fs0nlBC3EuvkOLnXQKxtx4A==",
+      "dev": true,
+      "dependencies": {
+        "@jest/get-type": "30.1.0",
+        "chalk": "^4.1.2",
+        "jest-diff": "30.4.1",
+        "pretty-format": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-message-util": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.4.1.tgz",
+      "integrity": "sha512-kwCKIvq0MCW1HzLoGola9Te6JUdzgV0loyKJ3Qghrkz9i5/RRIHsL95BMQc2HBBhlBKC4j22K9p11TGHH8RBpQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@jest/types": "30.4.1",
+        "@types/stack-utils": "^2.0.3",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "jest-util": "30.4.1",
+        "picomatch": "^4.0.3",
+        "pretty-format": "30.4.1",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.6"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-mock": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.4.1.tgz",
+      "integrity": "sha512-/i8SVb8/NSB7RfNi8gfqu8gxLV23KaL5EpAttyb9iz8qWRIqXRLflycz/32wXsYkOnaUlx8NAKnJYtpsmXUmfw==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "jest-util": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-pnp-resolver": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
+      "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      },
+      "peerDependencies": {
+        "jest-resolve": "*"
+      },
+      "peerDependenciesMeta": {
+        "jest-resolve": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-regex-util": {
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.4.0.tgz",
+      "integrity": "sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==",
+      "dev": true,
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-resolve": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-30.4.1.tgz",
+      "integrity": "sha512-Zry8Yq/yJcNAZ7dJ5F2heic8AheXvbFZ7XI5V+h28nrYZ7Qoyy4dItq8OodjnYD270mvX+ZudmrNV9cysqhW5Q==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "jest-haste-map": "30.4.1",
+        "jest-pnp-resolver": "^1.2.3",
+        "jest-util": "30.4.1",
+        "jest-validate": "30.4.1",
+        "slash": "^3.0.0",
+        "unrs-resolver": "^1.7.11"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-resolve-dependencies": {
+      "version": "30.4.2",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-30.4.2.tgz",
+      "integrity": "sha512-gDiVh1I+GxYzz9oXlyw+1wv6VOYX1WYxMOfjsA3iGKePV2oxmbHhwxfkALxNxYy1ciw6APWwkW2zZONwP97aEQ==",
+      "dev": true,
+      "dependencies": {
+        "jest-regex-util": "30.4.0",
+        "jest-snapshot": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-runner": {
+      "version": "30.4.2",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-30.4.2.tgz",
+      "integrity": "sha512-2dw0PslVYXxffXGpLo+Ejad+KcI1Qkjn7f4X4619gf21oCUmL+SPfjqIa/losUem3yEOvfNZe/F1HWUcNpODcg==",
+      "dev": true,
+      "dependencies": {
+        "@jest/console": "30.4.1",
+        "@jest/environment": "30.4.1",
+        "@jest/test-result": "30.4.1",
+        "@jest/transform": "30.4.1",
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "emittery": "^0.13.1",
+        "exit-x": "^0.2.2",
+        "graceful-fs": "^4.2.11",
+        "jest-docblock": "30.4.0",
+        "jest-environment-node": "30.4.1",
+        "jest-haste-map": "30.4.1",
+        "jest-leak-detector": "30.4.1",
+        "jest-message-util": "30.4.1",
+        "jest-resolve": "30.4.1",
+        "jest-runtime": "30.4.2",
+        "jest-util": "30.4.1",
+        "jest-watcher": "30.4.1",
+        "jest-worker": "30.4.1",
+        "p-limit": "^3.1.0",
+        "source-map-support": "0.5.13"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-runtime": {
+      "version": "30.4.2",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-30.4.2.tgz",
+      "integrity": "sha512-3/5e8iPz2k/VLqlr8DgTftYyLUv8Su3FkCAO2/Od81UsUTpSxOrS6O5x5KkoQwyUjmpYyDJKeyAvg2T2nvpNkQ==",
+      "dev": true,
+      "dependencies": {
+        "@jest/environment": "30.4.1",
+        "@jest/fake-timers": "30.4.1",
+        "@jest/globals": "30.4.1",
+        "@jest/source-map": "30.0.1",
+        "@jest/test-result": "30.4.1",
+        "@jest/transform": "30.4.1",
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "cjs-module-lexer": "^2.1.0",
+        "collect-v8-coverage": "^1.0.2",
+        "glob": "^10.5.0",
+        "graceful-fs": "^4.2.11",
+        "jest-haste-map": "30.4.1",
+        "jest-message-util": "30.4.1",
+        "jest-mock": "30.4.1",
+        "jest-regex-util": "30.4.0",
+        "jest-resolve": "30.4.1",
+        "jest-snapshot": "30.4.1",
+        "jest-util": "30.4.1",
+        "slash": "^3.0.0",
+        "strip-bom": "^4.0.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/brace-expansion": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/strip-bom": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+      "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-snapshot": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-30.4.1.tgz",
+      "integrity": "sha512-tEOkkfOMppUyeiHwjZswOQ3lcnoTnws/q5FnGIaeIh/jmoU0ZlgMYRR8sTlTj+nNGCoJ0RDq6SfxGxCsyMTPmw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.27.4",
+        "@babel/generator": "^7.27.5",
+        "@babel/plugin-syntax-jsx": "^7.27.1",
+        "@babel/plugin-syntax-typescript": "^7.27.1",
+        "@babel/types": "^7.27.3",
+        "@jest/expect-utils": "30.4.1",
+        "@jest/get-type": "30.1.0",
+        "@jest/snapshot-utils": "30.4.1",
+        "@jest/transform": "30.4.1",
+        "@jest/types": "30.4.1",
+        "babel-preset-current-node-syntax": "^1.2.0",
+        "chalk": "^4.1.2",
+        "expect": "30.4.1",
+        "graceful-fs": "^4.2.11",
+        "jest-diff": "30.4.1",
+        "jest-matcher-utils": "30.4.1",
+        "jest-message-util": "30.4.1",
+        "jest-util": "30.4.1",
+        "pretty-format": "30.4.1",
+        "semver": "^7.7.2",
+        "synckit": "^0.11.8"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-snapshot/node_modules/semver": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/jest-util": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.4.1.tgz",
+      "integrity": "sha512-vjQb1sACEiv13DKJMDToJpzVW0joCsIQrmbg0fi7CyOOt+g9jTuQl2A216pWRBYhOVt53XbL/2LbMKg1BECWOw==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-validate": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-30.4.1.tgz",
+      "integrity": "sha512-PDWi4SOwLnwqNDfHZjOcsEFyZ4fc/2W2gVL3DEoyqnB6jCQMLRtfBong8s6omIw3lI0HWOus12xfnFmQtjW3fw==",
+      "dev": true,
+      "dependencies": {
+        "@jest/get-type": "30.1.0",
+        "@jest/types": "30.4.1",
+        "camelcase": "^6.3.0",
+        "chalk": "^4.1.2",
+        "leven": "^3.1.0",
+        "pretty-format": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-validate/node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-watcher": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-30.4.1.tgz",
+      "integrity": "sha512-/l9UonmvCwjHH7d2h3iAwIloLc1H0S8mJZ/LNK3i86hqwPAz8otUJjP9MfYtz9Tt77Su5FD2xGjZn8d31IZHlw==",
+      "dev": true,
+      "dependencies": {
+        "@jest/test-result": "30.4.1",
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "ansi-escapes": "^4.3.2",
+        "chalk": "^4.1.2",
+        "emittery": "^0.13.1",
+        "jest-util": "30.4.1",
+        "string-length": "^4.0.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-worker": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-30.4.1.tgz",
+      "integrity": "sha512-SHynN/q/QD++iNyvMdy+WMmbCGk8jIsNcRxycXbWubSOhvo6T+j2afcfUSl+3hYsiBebOTo0cT7c2H7CXugu1g==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "@ungap/structured-clone": "^1.3.0",
+        "jest-util": "30.4.1",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.1.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-worker/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
+    },
     "node_modules/js-yaml": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
@@ -2996,11 +6116,29 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "license": "MIT"
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -3119,6 +6257,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/leven": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+      "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -3131,6 +6278,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true
     },
     "node_modules/locate-path": {
       "version": "6.0.0",
@@ -3209,6 +6362,42 @@
         "node": ">=10"
       }
     },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/makeerror": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
+      "integrity": "sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==",
+      "dev": true,
+      "dependencies": {
+        "tmpl": "1.0.5"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -3235,6 +6424,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true
     },
     "node_modules/methods": {
       "version": "1.1.2",
@@ -3278,6 +6473,15 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -3298,6 +6502,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/morgan": {
@@ -3334,6 +6547,21 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
+    "node_modules/napi-postinstall": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.4.tgz",
+      "integrity": "sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==",
+      "dev": true,
+      "bin": {
+        "napi-postinstall": "lib/cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/napi-postinstall"
+      }
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -3347,6 +6575,42 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-int64": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+      "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
+      "dev": true
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.47",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.47.tgz",
+      "integrity": "sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/object-assign": {
@@ -3500,6 +6764,21 @@
         "wrappy": "1"
       }
     },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/openapi-types": {
       "version": "12.1.3",
       "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
@@ -3572,6 +6851,21 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -3582,6 +6876,24 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/parseurl": {
@@ -3625,6 +6937,28 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "license": "MIT"
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true
     },
     "node_modules/path-to-regexp": {
       "version": "0.1.12",
@@ -3733,6 +7067,97 @@
         "split2": "^4.1.0"
       }
     },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/pkg-dir": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+      "dev": true,
+      "dependencies": {
+        "find-up": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -3806,6 +7231,33 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
+      "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
+      "dev": true,
+      "dependencies": {
+        "@jest/schemas": "30.4.1",
+        "ansi-styles": "^5.2.0",
+        "react-is-18": "npm:react-is@^18.3.1",
+        "react-is-19": "npm:react-is@^19.2.5"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -3833,6 +7285,22 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/pure-rand": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-7.0.1.tgz",
+      "integrity": "sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ]
     },
     "node_modules/qs": {
       "version": "6.14.0",
@@ -3914,6 +7382,20 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/react-is-18": {
+      "name": "react-is",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true
+    },
+    "node_modules/react-is-19": {
+      "name": "react-is",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.7.tgz",
+      "integrity": "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==",
+      "dev": true
     },
     "node_modules/rechoir": {
       "version": "0.8.0",
@@ -4008,6 +7490,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.10",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
@@ -4026,6 +7517,27 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-cwd": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+      "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
+      "dev": true,
+      "dependencies": {
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/resolve-cwd/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/resolve-from": {
@@ -4392,6 +7904,40 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true
+    },
+    "node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+      "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+      "dev": true,
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
     "node_modules/split2": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
@@ -4399,6 +7945,33 @@
       "license": "ISC",
       "engines": {
         "node": ">= 10.x"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true
+    },
+    "node_modules/stack-utils": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+      "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
+      "dev": true,
+      "dependencies": {
+        "escape-string-regexp": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/stack-utils/node_modules/escape-string-regexp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/standard-as-callback": {
@@ -4428,6 +8001,48 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/string-length": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
+      "integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
+      "dev": true,
+      "dependencies": {
+        "char-regex": "^1.0.2",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/string.prototype.trim": {
@@ -4501,6 +8116,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-bom": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
@@ -4509,6 +8137,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/strip-json-comments": {
@@ -4521,6 +8158,84 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/superagent": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
+      "integrity": "sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==",
+      "dev": true,
+      "dependencies": {
+        "component-emitter": "^1.3.1",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.7",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.5",
+        "formidable": "^3.5.4",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.14.1"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/superagent/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/superagent/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/superagent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
+    },
+    "node_modules/supertest": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.2.2.tgz",
+      "integrity": "sha512-oK8WG9diS3DlhdUkcFn4tkNIiIbBx9lI2ClF8K+b2/m8Eyv47LSawxUzZQSNKUrVb2KsqeTDCcjAAVPYaSLVTA==",
+      "dev": true,
+      "dependencies": {
+        "cookie-signature": "^1.2.2",
+        "methods": "^1.1.2",
+        "superagent": "^10.3.0"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/supertest/node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.6.0"
       }
     },
     "node_modules/supports-color": {
@@ -4633,6 +8348,21 @@
         "express": ">=4.0.0 || >=5.0.0-beta"
       }
     },
+    "node_modules/synckit": {
+      "version": "0.11.13",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.13.tgz",
+      "integrity": "sha512-eNRKgb3z66Yp3D2CixVujOUvXLFUTij/zVnV8KRyvFdQwpz7I5DS8UfRkTeLzb64u+dkzDSdelE24izu+zSSUg==",
+      "dev": true,
+      "dependencies": {
+        "@pkgr/core": "^0.3.6"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/synckit"
+      }
+    },
     "node_modules/tarn": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/tarn/-/tarn-3.0.2.tgz",
@@ -4640,6 +8370,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+      "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+      "dev": true,
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^7.1.4",
+        "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/text-table": {
@@ -4656,6 +8400,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/tmpl": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
+      "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
+      "dev": true
     },
     "node_modules/toidentifier": {
       "version": "1.0.1",
@@ -4695,6 +8445,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/type-fest": {
@@ -4819,6 +8578,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "dev": true
+    },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -4826,6 +8591,73 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/unrs-resolver": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.12.2.tgz",
+      "integrity": "sha512-dmlRxBJJayXjqTwC+JtF1HhJmgf3ftQ3YejFcZrf4+KKtJv0qDsK1pjqaaVjG7wJ5NJ6UVP1OqRMQ71Z4C3rxQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "napi-postinstall": "^0.3.4"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unrs-resolver"
+      },
+      "optionalDependencies": {
+        "@unrs/resolver-binding-android-arm-eabi": "1.12.2",
+        "@unrs/resolver-binding-android-arm64": "1.12.2",
+        "@unrs/resolver-binding-darwin-arm64": "1.12.2",
+        "@unrs/resolver-binding-darwin-x64": "1.12.2",
+        "@unrs/resolver-binding-freebsd-x64": "1.12.2",
+        "@unrs/resolver-binding-linux-arm-gnueabihf": "1.12.2",
+        "@unrs/resolver-binding-linux-arm-musleabihf": "1.12.2",
+        "@unrs/resolver-binding-linux-arm64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-arm64-musl": "1.12.2",
+        "@unrs/resolver-binding-linux-loong64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-loong64-musl": "1.12.2",
+        "@unrs/resolver-binding-linux-ppc64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-riscv64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-riscv64-musl": "1.12.2",
+        "@unrs/resolver-binding-linux-s390x-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-x64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-x64-musl": "1.12.2",
+        "@unrs/resolver-binding-openharmony-arm64": "1.12.2",
+        "@unrs/resolver-binding-wasm32-wasi": "1.12.2",
+        "@unrs/resolver-binding-win32-arm64-msvc": "1.12.2",
+        "@unrs/resolver-binding-win32-ia32-msvc": "1.12.2",
+        "@unrs/resolver-binding-win32-x64-msvc": "1.12.2"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
       }
     },
     "node_modules/uri-js": {
@@ -4855,6 +8687,20 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/v8-to-istanbul": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
+      "integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.12",
+        "@types/istanbul-lib-coverage": "^2.0.1",
+        "convert-source-map": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
     "node_modules/validator": {
       "version": "13.15.23",
       "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.23.tgz",
@@ -4871,6 +8717,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/walker": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
+      "integrity": "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==",
+      "dev": true,
+      "dependencies": {
+        "makeerror": "1.0.12"
       }
     },
     "node_modules/which": {
@@ -4992,11 +8847,71 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/write-file-atomic": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
+      "integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
+      "dev": true,
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/write-file-atomic/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/xtend": {
       "version": "4.0.2",
@@ -5005,6 +8920,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/yallist": {
@@ -5020,6 +8944,33 @@
       "license": "ISC",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/yocto-queue": {

--- a/web-api/package.json
+++ b/web-api/package.json
@@ -4,7 +4,15 @@
   "private": true,
   "scripts": {
     "start": "node ./bin/www",
-    "lint:fix": "eslint --fix . --ext .js,.jsx --ignore-path .gitignore"
+    "lint:fix": "eslint --fix . --ext .js,.jsx --ignore-path .gitignore",
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "test:coverage": "jest --coverage"
+  },
+  "jest": {
+    "testEnvironment": "node",
+    "testMatch": ["**/__tests__/**/*.test.js"],
+    "setupFiles": ["<rootDir>/__tests__/setup.js"]
   },
   "dependencies": {
     "@mapbox/sphericalmercator": "^1.1.0",
@@ -30,16 +38,18 @@
     "pg-parse-float": "^0.0.1",
     "prettier": "^2.7.1",
     "redis": "5.8.2",
+    "swagger-jsdoc": "^6.2.8",
+    "swagger-ui-express": "^5.0.0",
     "uuid": "^8.3.2",
     "validator": "^13.7.0",
-    "wkt": "^0.1.1",
-    "swagger-jsdoc": "^6.2.8",
-    "swagger-ui-express": "^5.0.0"
+    "wkt": "^0.1.1"
   },
   "devDependencies": {
     "eslint": "^8.24.0",
     "eslint-config-airbnb-base": "^15.0.0",
-    "eslint-plugin-import": "^2.26.0"
+    "eslint-plugin-import": "^2.26.0",
+    "jest": "^30.4.2",
+    "supertest": "^7.2.2"
   },
   "overrides": {
     "qs": "^6.13.0",


### PR DESCRIPTION
## Overview
This pull request introduces a comprehensive backend and frontend test infrastructure alongside a new harvest validation package. It also introduces extensive documentation and makes necessary dependency updates to support the new testing framework.

## Key Changes
*   **Backend Test Suite:** Added a new `tests/` package featuring `conftest.py`, 9 unit test modules (covering CKAN, ERDDAP, CSV generation, and more), and a pipeline integration smoke test.
*   **Frontend Test Suite:** Added 10 Jest test files under `web-api/__tests__/` covering core API routes and utility functions with a shared mock database helper.
*   **Harvest Validator:** Introduced the `harvester/harvest_validator/` package to run end-to-end harvests, collect diagnostics, and generate structured reports.
*   **Logger Fallback:** Patched `harvest_erddap.py` to make the logger injectable, decoupled from live infrastructure for isolated testing.
*   **Dependencies & Docs:** Updated `pyproject.toml` and `package.json` with new testing/utility libraries, regenerated lockfiles, and added thorough technical documentation under `docs/`.

## Notes for Reviewers
*   **Validation Reports:** Check `tests/validation_reports/`. These are timestamped artifacts—should they be added to `.gitignore`?
*   **UML Diagram:** `harvester/uml_diagram.txt` is included but may be out of date. Please review before merging.
*   **Lockfiles:** `tests/uv.lock` is checked in alongside the root `uv.lock`. Please confirm if this dual-lockfile setup is intentional.

## Testing Checklist
- [ ] Run backend unit tests: `cd tests && uv run pytest`
- [ ] Run backend integration smoke tests: `uv run pytest tests/integration/`
- [ ] Run frontend Jest tests: `cd web-api && npm test`
- [ ] Verify validation CLI: `python -m harvest_validator --help` (from `harvester/`)
