### PR TITLE
harvester: honor HARVEST_CONFIG_FILE env var in Prefect config resolution

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -83,3 +83,9 @@ HARVEST_FLOW_NAME=Harvest Source
 # /app/harvester/harvest_config.yaml (relative to the compose file). Change it
 # and restart the worker — no rebuild needed. Defaults to the committed sample.
 HARVEST_CONFIG_FILE=harvest_config.sample.yaml
+
+# Alternative to HARVEST_CONFIG_FILE: paste the full harvest config YAML inline
+# instead of mounting a file. Useful on hosted platforms (e.g. Coolify) where you
+# set config in a secret field rather than mounting a volume. When set, this takes
+# precedence over HARVEST_CONFIG_FILE. Leave empty to use HARVEST_CONFIG_FILE.
+# HARVEST_CONFIG_YAML=

--- a/harvester/cde_harvester/prefect_pipeline.py
+++ b/harvester/cde_harvester/prefect_pipeline.py
@@ -462,11 +462,12 @@ def _normalize_coolify_multiline(value: str) -> str:
 
 
 def _resolve_harvest_config_file(config_file):
-    """Resolve effective config: HARVEST_CONFIG_YAML env > mounted/baked-in default.
+    """Resolve effective config: HARVEST_CONFIG_YAML env > HARVEST_CONFIG_FILE env > baked-in default.
 
     Also writes OBIS_DATASETS_JSON to /tmp/Obis_Datasets.json when set.
     """
     env_config = os.getenv("HARVEST_CONFIG_YAML", "").strip()
+    env_config_file = os.getenv("HARVEST_CONFIG_FILE", "").strip()
     if env_config:
         # Coolify indents multi-line env var continuations; strip it so the YAML parses.
         env_config = _normalize_coolify_multiline(env_config)
@@ -474,6 +475,9 @@ def _resolve_harvest_config_file(config_file):
         env_config_path.write_text(env_config)
         config_file = str(env_config_path)
         logger.info(f"Using HARVEST_CONFIG_YAML env var ({len(env_config)} bytes -> {env_config_path})")
+    elif env_config_file:
+        config_file = env_config_file
+        logger.info(f"Using HARVEST_CONFIG_FILE env var: {config_file}")
     else:
         logger.info(f"Using harvest config file: {config_file}")
 


### PR DESCRIPTION
The Prefect runtime (_resolve_harvest_config_file) only read the inline HARVEST_CONFIG_YAML and otherwise fell back to the hardcoded config_file param, so the HARVEST_CONFIG_FILE path env var set by .env and both compose files was silently ignored — only the legacy __main__.py CLI consulted it.

Add a fallback branch so HARVEST_CONFIG_FILE resolves the config path when HARVEST_CONFIG_YAML is unset, giving precedence: HARVEST_CONFIG_YAML > HARVEST_CONFIG_FILE > baked-in default.

Also document HARVEST_CONFIG_YAML (the inline alternative) in .env.sample.